### PR TITLE
[codex] Fix pasted image refresh race in Codex browser

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -79,6 +79,23 @@ function recordsAreEqual(left, right) {
   return JSON.stringify(left) === JSON.stringify(right)
 }
 
+function storeChangedSinceSnapshot(editor, baselineStore) {
+  const currentStore = editor.store.getStoreSnapshot().store
+  const baselineIds = new Set(Object.keys(baselineStore))
+
+  for (const [id, baselineRecord] of Object.entries(baselineStore)) {
+    const currentRecord = currentStore[id]
+    if (!currentRecord) return true
+    if (!recordsAreEqual(currentRecord, baselineRecord)) return true
+  }
+
+  for (const id of Object.keys(currentStore)) {
+    if (!baselineIds.has(id)) return true
+  }
+
+  return false
+}
+
 function applyRemoteCanvasSnapshot(editor, snapshot, { preserveLocalChanges = false } = {}) {
   if (!isCanvasSnapshot(snapshot)) return 0
 
@@ -844,7 +861,9 @@ export default function App() {
       remoteLoadController?.abort()
       const controller = new AbortController()
       remoteLoadController = controller
+
       const preserveLocalChanges = hasUnsavedChanges || isSaving
+      const preFetchStore = preserveLocalChanges ? null : editor.store.getStoreSnapshot().store
 
       try {
         const response = await fetch(CANVAS_ENDPOINT, { signal: controller.signal })
@@ -853,11 +872,13 @@ export default function App() {
         }
 
         const canvasData = await response.json()
+        const effectivePreserve =
+          preserveLocalChanges || (preFetchStore && storeChangedSinceSnapshot(editor, preFetchStore))
         const changedRecords = applyRemoteCanvasSnapshot(editor, canvasData.snapshot, {
-          preserveLocalChanges
+          preserveLocalChanges: effectivePreserve
         })
 
-        if (changedRecords > 0 && preserveLocalChanges) {
+        if (changedRecords > 0 && effectivePreserve) {
           hasUnsavedChanges = true
           if (isSaving) {
             hasPendingSave = true

--- a/vite.config.js
+++ b/vite.config.js
@@ -276,7 +276,7 @@ async function localizePageAsset(asset, pageId) {
   if (!dataUrl && !sourceFilePath) return localizedAsset
 
   const fileName = sanitizeAssetFileName(
-    localizedAsset.props.name,
+    dataUrl ? null : localizedAsset.props.name,
     sourceFilePath ? basename(sourceFilePath) : localizedAsset.id.replace(':', '-'),
     dataUrl?.mimeType ?? localizedAsset.props.mimeType
   )


### PR DESCRIPTION
## Summary

Fixes #2

This fixes a Codex in-app browser regression where pasted image content could briefly appear correctly and then revert to an older image after a remote canvas refresh.

## Root Cause

The canvas refresh path could fetch a remote snapshot while the local store changed during the request. The previous protection only looked at `hasUnsavedChanges` / `isSaving` before the fetch, so local paste changes made during the fetch window could still be overwritten by stale remote records.

There was also an asset localization collision for pasted data URL images: tldraw can assign repeated names like `Pasted Image`, causing multiple pasted assets to resolve to the same localized file name.

## Changes

- Added full store baseline comparison before applying remote snapshots.
- Detects in-flight local store changes, including newly added records from pasted images.
- Preserves local changes when a stale remote snapshot arrives during that window.
- Uses asset-id fallback names for data URL assets to avoid pasted image file collisions.

## Validation

- Ran `npm run build` in the source checkout.
- Synced the installed Cowart plugin cache used by Codex.
- Ran `npm run build` in the installed plugin cache.
- Restarted the installed Cowart service at `http://127.0.0.1:43217/`.
- Verified `http://127.0.0.1:43217/` returns HTTP 200.
- Manually tested in the Codex in-app browser: pasted images with `Ctrl+V` no longer reverted to previous image content.

