### PR TITLE
[codex] Fix Cowart imagegen output extraction

### DIFF
--- a/skills/cowart-image-gen/SKILL.md
+++ b/skills/cowart-image-gen/SKILL.md
@@ -67,15 +67,43 @@ meta flag. Support both shapes.
 
    If the holder is a legacy `geo` rectangle, keep using the legacy placement contract: same `x`, `y`, `rotation`, `parentId`, `props.w`, and `props.h` as the holder.
 
-4. Generate the bitmap with the built-in `imagegen` skill unless the user explicitly requests another image path. If the requested asset needs visible copy, labels, poster text, ad text, UI text, or typography, include that text directly in the image generation prompt and let the image model produce the final bitmap. Do not default to generating a text-free background and then adding text locally unless the user explicitly asks for local typography, deterministic text overlay, SVG/vector output, or another non-imagegen layout step.
+4. Record a generation cutoff timestamp before calling the image tool:
 
-   For project-bound output, copy the selected generated image from `$CODEX_HOME/generated_images/...` into the selected page's asset folder:
+   ```bash
+   date -u +"%Y-%m-%dT%H:%M:%SZ"
+   ```
+
+5. Generate the bitmap with the built-in `imagegen` skill unless the user explicitly requests another image path. If the requested asset needs visible copy, labels, poster text, ad text, UI text, or typography, include that text directly in the image generation prompt and let the image model produce the final bitmap. Do not default to generating a text-free background and then adding text locally unless the user explicitly asks for local typography, deterministic text overlay, SVG/vector output, or another non-imagegen layout step.
+
+6. Resolve the actual generated bitmap file. Do not assume that `$CODEX_HOME/generated_images/...` contains the latest built-in image output; some Codex desktop sessions store the generated PNG directly in the session JSONL as `image_generation_call.result` base64 without writing a new file under `generated_images`.
+
+   First, look for a generated image file modified after the cutoff timestamp:
+
+   ```bash
+   find "${CODEX_HOME:-$HOME/.codex}/generated_images" -type f \
+     \( -name '*.png' -o -name '*.jpg' -o -name '*.jpeg' -o -name '*.webp' \) \
+     -newermt "<cutoff-timestamp>" -print
+   ```
+
+   If no new file exists, extract the latest built-in image result from the Codex session JSONL:
+
+   ```bash
+   node skills/cowart-image-gen/scripts/extract-latest-imagegen-result.mjs \
+     --after "<cutoff-timestamp>" \
+     --out /tmp/cowart-imagegen-result.png
+   ```
+
+   The helper defaults to the newest session under `${CODEX_HOME:-$HOME/.codex}/sessions`. Pass `--session /path/to/session.jsonl` if the current session is not the newest session file.
+
+7. Inspect the resolved local image before inserting it. Use `view_image` when available, or another direct visual check. Continue only after confirming that the local file matches the user's prompt. Never insert a file selected only by "latest directory" or by an old `generated_images` folder name.
+
+   For project-bound output, copy the verified local generated image into the selected page's asset folder:
 
    ```text
    canvas/pages/<page-id-without-page-prefix>/assets/
    ```
 
-5. Insert the generated image as a new tldraw image shape exactly over the holder:
+8. Insert the verified generated image as a new tldraw image shape exactly over the holder:
 
    - `type`: `image`
    - `parentId`: holder id for frame holders, same as holder parent for legacy geo holders
@@ -84,9 +112,9 @@ meta flag. Support both shapes.
    - `props.assetId`: the new image asset id
    - `meta.cowartGeneratedForAiImageHolder`: holder shape id
 
-6. Do not delete the holder unless the user explicitly asks for replacement. Keeping the holder lets Codex identify the intended slot again later.
+9. Do not delete the holder unless the user explicitly asks for replacement. Keeping the holder lets Codex identify the intended slot again later.
 
-7. Save through Cowart's API or edit the page snapshot carefully:
+10. Save through Cowart's API or edit the page snapshot carefully:
 
    ```bash
    curl -s http://127.0.0.1:43217/api/canvas
@@ -98,7 +126,7 @@ meta flag. Support both shapes.
    /page-assets/<page-id-without-page-prefix>/<filename>
    ```
 
-8. Refresh or let the browser hot-reload, then confirm the inserted shape id, holder id, final dimensions, and saved asset path.
+11. Refresh or let the browser hot-reload, then confirm the inserted shape id, holder id, final dimensions, and saved asset path.
 
 ## Notes
 

--- a/skills/cowart-image-gen/scripts/extract-latest-imagegen-result.mjs
+++ b/skills/cowart-image-gen/scripts/extract-latest-imagegen-result.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises'
+import { basename, dirname, join, resolve } from 'node:path'
+
+function parseArgs(argv) {
+  const args = {}
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (!arg.startsWith('--')) continue
+    const key = arg.slice(2)
+    const next = argv[index + 1]
+    if (!next || next.startsWith('--')) {
+      args[key] = true
+    } else {
+      args[key] = next
+      index += 1
+    }
+  }
+  return args
+}
+
+function usage() {
+  return `Usage:
+  node skills/cowart-image-gen/scripts/extract-latest-imagegen-result.mjs --out /tmp/image.png [--session /path/session.jsonl] [--after ISO_TIMESTAMP]
+
+Extracts the latest built-in image_gen result from a Codex session JSONL file.
+The built-in image tool may store PNG base64 in image_generation_call.result
+without writing a file under $CODEX_HOME/generated_images.`
+}
+
+async function newestJsonlFile(dir) {
+  const entries = []
+
+  async function walk(currentDir) {
+    for (const entry of await readdir(currentDir, { withFileTypes: true })) {
+      const fullPath = join(currentDir, entry.name)
+      if (entry.isDirectory()) {
+        await walk(fullPath)
+      } else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+        const info = await stat(fullPath)
+        entries.push({ path: fullPath, mtimeMs: info.mtimeMs })
+      }
+    }
+  }
+
+  await walk(dir)
+  entries.sort((a, b) => b.mtimeMs - a.mtimeMs)
+  return entries[0]?.path ?? null
+}
+
+function isPngBase64(value) {
+  return typeof value === 'string' && value.startsWith('iVBOR')
+}
+
+const args = parseArgs(process.argv.slice(2))
+
+if (args.help || !args.out) {
+  console.log(usage())
+  process.exit(args.help ? 0 : 2)
+}
+
+const codexHome = process.env.CODEX_HOME || join(process.env.HOME || '', '.codex')
+const sessionPath = args.session
+  ? resolve(String(args.session))
+  : await newestJsonlFile(join(codexHome, 'sessions'))
+
+if (!sessionPath) {
+  throw new Error(`Could not find a Codex session JSONL file under ${join(codexHome, 'sessions')}`)
+}
+
+const afterTime = args.after ? Date.parse(String(args.after)) : null
+if (args.after && Number.isNaN(afterTime)) {
+  throw new Error(`Invalid --after timestamp: ${args.after}`)
+}
+
+const text = await readFile(sessionPath, 'utf8')
+let latest = null
+for (const [lineIndex, line] of text.split(/\r?\n/).entries()) {
+  if (!line.trim()) continue
+  let event
+  try {
+    event = JSON.parse(line)
+  } catch {
+    continue
+  }
+
+  const payload = event.payload
+  if (event.type !== 'response_item' || payload?.type !== 'image_generation_call') continue
+  if (payload.status !== 'completed' && payload.status !== 'generating') continue
+  if (!isPngBase64(payload.result)) continue
+
+  const timestampMs = Date.parse(event.timestamp || '')
+  if (afterTime !== null && (!Number.isFinite(timestampMs) || timestampMs < afterTime)) continue
+
+  latest = {
+    id: payload.id || `line-${lineIndex + 1}`,
+    line: lineIndex + 1,
+    revisedPrompt: payload.revised_prompt || '',
+    result: payload.result,
+    sessionPath,
+    timestamp: event.timestamp || null,
+  }
+}
+
+if (!latest) {
+  throw new Error(`No PNG image_generation_call.result found in ${sessionPath}`)
+}
+
+const outPath = resolve(String(args.out))
+await mkdir(dirname(outPath), { recursive: true })
+const bytes = Buffer.from(latest.result, 'base64')
+await writeFile(outPath, bytes)
+
+console.log(JSON.stringify({
+  id: latest.id,
+  line: latest.line,
+  sessionPath: latest.sessionPath,
+  timestamp: latest.timestamp,
+  outputPath: outPath,
+  fileName: basename(outPath),
+  bytes: bytes.length,
+  revisedPrompt: latest.revisedPrompt,
+}, null, 2))


### PR DESCRIPTION
## Summary
- document the built-in image generation output path fallback in the Cowart image generation skill
- add a helper that extracts PNG base64 from `image_generation_call.result` in Codex session JSONL files
- require visual verification of the resolved local image before inserting it into an AI image holder

## Root Cause
The existing workflow assumed built-in image generation always writes a new file under `$CODEX_HOME/generated_images`. In Codex desktop, generated PNGs can instead be stored in the session JSONL as `image_generation_call.result` without a new generated_images file. That made agents vulnerable to picking an old asset from a stale generated_images directory.

## Validation
- `node --check skills/cowart-image-gen/scripts/extract-latest-imagegen-result.mjs`
- `node skills/cowart-image-gen/scripts/extract-latest-imagegen-result.mjs --session /Users/xieminghua/.codex/sessions/2026/06/21/rollout-2026-06-21T13-15-35-019ee89b-096e-7a82-8989-974fecce489f.jsonl --after 2026-06-21T05:19:00Z --out /tmp/cowart-pr-test.png`
- `PATH=/Users/xieminghua/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run build`