### PR TITLE
fix(deps): 添加缺失的 @tiptap/pm 直接依赖

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,14 @@
       "name": "cowart-canvas",
       "version": "0.1.2",
       "dependencies": {
-        "@tiptap/pm": "^3.27.0",
+        "@tiptap/pm": "3.27.0",
         "@vitejs/plugin-react": "^5.0.0",
         "fractional-indexing": "^3.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tldraw": "^5.1.1",
         "vite": "^7.0.0"
-      },
-      "devDependencies": {}
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cowart-canvas",
       "version": "0.1.2",
       "dependencies": {
+        "@tiptap/pm": "^3.27.0",
         "@vitejs/plugin-react": "^5.0.0",
         "fractional-indexing": "^3.2.0",
         "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tiptap/pm": "3.27.0",
     "@vitejs/plugin-react": "^5.0.0",
     "fractional-indexing": "^3.2.0",
-    "vite": "^7.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tldraw": "^5.1.1"
-  },
-  "devDependencies": {}
+    "tldraw": "^5.1.1",
+    "vite": "^7.0.0"
+  }
 }


### PR DESCRIPTION
## 问题

`src/App.jsx` 直接导入 `@tiptap/pm/state` 的 `AllSelection`，但 `package.json` 未声明该依赖。npm 扁平安装下碰巧可用，pnpm/严格模式下会报 Module not found。

## 修复

显式添加 `@tiptap/pm@3.27.0` 到 `dependencies`，版本与 tldraw peerDep 对齐。

Closes #10