### PR TITLE
feat: 空白画布打开时自动创建 AI image holder

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -100,14 +100,14 @@ canvas/pages/<page-id>/assets/
 ### Generate A New Image
 
 1. Open the Cowart canvas.
-2. Create and select an AI image holder on the canvas.
+2. Optionally create and select an AI image holder on the canvas to define the image size and placement.
 3. Describe the image you want Codex to generate, for example:
 
 ```text
 Generate a new image into the selected Cowart AI image holder.
 ```
 
-Codex reads the selected holder, matches its aspect ratio, generates the image, and inserts it into the holder.
+When an empty canvas is opened, Cowart automatically creates one AI image holder so the first image generation has a ready target. If the canvas already has content, Cowart does not add another holder automatically; you can still create or select another holder on the canvas to define the image size and placement. When a holder is selected, Codex reads its aspect ratio, generates the image, and inserts it into the holder.
 
 ![Generate and insert a new image with Cowart](assets/generate-image.png)
 

--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ canvas/pages/<page-id>/assets/
 ### 生成新图
 
 1. 打开 Cowart 画布。
-2. 在画布里创建并选中一个 AI image holder。
+2. 可以在画布里创建并选中一个 AI image holder，用来指定图片尺寸和位置。
 3. 在 Codex 中描述要生成的图片，例如：
 
 ```text
 Generate a new image into the selected Cowart AI image holder.
 ```
 
-Codex 会读取选中的 holder，按它的比例生成图片，并插入到 holder 中。
+打开空白画布时，Cowart 会自动创建一个 AI image holder，方便第一次生成图片时直接使用。如果画布已有内容，Cowart 不会自动添加新的 holder；你仍然可以在画布里手动创建或选中其他 holder 来指定图片尺寸和位置。选中 holder 时，Codex 会读取它的比例生成图片，并插入到 holder 中。
 
 ![使用 Cowart 生成并插入新图](assets/generate-image.png)
 

--- a/skills/cowart-open-canvas/SKILL.md
+++ b/skills/cowart-open-canvas/SKILL.md
@@ -17,7 +17,7 @@ Run this from the Cowart repository root. Use the active workspace or project di
 
 2. Open the resulting local URL in the Codex in-app browser when the Browser tool chain is available.
 
-The default URL is `http://127.0.0.1:43217/`. If the service output prints a different `Local:` URL, open that actual URL instead.
+The default URL is `http://127.0.0.1:43217/`. If the service output prints a different `Local:` URL, open that actual URL instead. When the canvas is empty, Cowart automatically creates one initial AI image holder; no special URL parameter is needed.
 
 Use the Browser plugin's `control-in-app-browser` skill as the source of truth for opening the in-app browser. The correct model-side flow is:
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -162,6 +162,17 @@ function createAiImageHolderAtViewportCenter(editor) {
   editor.setCurrentTool('select.idle')
 }
 
+function canvasIsEmpty(editor) {
+  return !Object.values(editor.store.getStoreSnapshot().store).some(
+    (record) => record?.typeName === 'shape'
+  )
+}
+
+function createInitialAiImageHolderForEmptyCanvas(editor) {
+  if (!canvasIsEmpty(editor)) return
+  createAiImageHolderAtViewportCenter(editor)
+}
+
 function startEditingAnnotationArrowLabel(editor, arrowId) {
   const shape = editor.getShape(arrowId)
   if (!shape || !editor.canEditShape(shape)) {
@@ -732,6 +743,7 @@ export default function App() {
 
     editor.timers.requestAnimationFrame(() => {
       restoreCowartViewState(editor, viewState)
+      createInitialAiImageHolderForEmptyCanvas(editor)
     })
 
     async function syncSelectionState() {


### PR DESCRIPTION
## 修改内容

- 打开空白 Cowart 画布时，自动创建一个 AI image holder，方便用户第一次生成图片时直接使用。
- 如果画布已经有内容，则不会自动新增 holder，避免影响用户已有画布。
- 用户后续仍然可以手动创建或选择其他 holder，用于指定图片尺寸和位置。
- 同步更新中文 README、英文 README 和 cowart-open-canvas skill 文档。

## 验证

- npm run build
- quick_validate.py skills/cowart-open-canvas
- git diff --check