### PR TITLE
fix(storage): avoid atomic write temp file collisions

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { randomUUID } from 'node:crypto'
 import { createReadStream } from 'node:fs'
 import { copyFile, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, dirname, extname, join, relative, resolve, sep } from 'node:path'
@@ -373,7 +374,7 @@ async function loadCanvasSnapshot() {
 
 async function writeJsonAtomic(filePath, payload) {
   await mkdir(dirname(filePath), { recursive: true })
-  const tempFile = `${filePath}.${process.pid}.tmp`
+  const tempFile = `${filePath}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`
   await writeFile(tempFile, `${JSON.stringify(payload, null, 2)}\n`)
   await rename(tempFile, filePath)
 }


### PR DESCRIPTION
## Summary

`writeJsonAtomic()` currently uses `${filePath}.${process.pid}.tmp` as its temporary file name. Two concurrent writes to the same JSON file inside the same Vite process can therefore share the same temp path and race before `rename()`.

This PR adds a timestamp and `crypto.randomUUID()` to the temp file name so each atomic write gets its own temporary path.

## Validation

- `npm run build`
- `git diff --check`