### PR TITLE
Fix native image paste in Codex desktop

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -639,6 +639,23 @@ const cowartUiOverrides = {
       'tool.cowart-annotation': ANNOTATION_TOOL_LABEL
     }
   },
+  actions(editor, actions) {
+    return {
+      ...actions,
+      paste: {
+        ...actions.paste,
+        kbd: undefined
+      },
+      'paste-at-cursor': {
+        ...actions['paste-at-cursor'],
+        kbd: undefined
+      },
+      'paste-plain-text-at-cursor': {
+        ...actions['paste-plain-text-at-cursor'],
+        kbd: undefined
+      }
+    }
+  },
   tools(editor, tools) {
     return {
       ...tools,
@@ -691,6 +708,58 @@ const cowartUiOverrides = {
 const cowartComponents = {
   Toolbar: CowartToolbar,
   StylePanel: CowartStylePanel
+}
+
+function getFilesFromPasteEvent(event) {
+  const clipboardData = event.clipboardData
+  if (!clipboardData) return []
+
+  const files = Array.from(clipboardData.files ?? [])
+  if (files.length > 0) return files
+
+  return Array.from(clipboardData.items ?? [])
+    .filter((item) => item.kind === 'file')
+    .map((item) => item.getAsFile())
+    .filter(Boolean)
+}
+
+function getTextFromPasteEvent(event) {
+  const clipboardData = event.clipboardData
+  if (!clipboardData) return null
+
+  const html = clipboardData.getData('text/html')
+  const text = clipboardData.getData('text/plain')
+  if (!html && !text) return null
+
+  return { html, text }
+}
+
+const cowartTldrawOptions = {
+  onClipboardPasteRaw(info) {
+    if (info.source !== 'native-event') return
+
+    const files = getFilesFromPasteEvent(info.event)
+    if (files.length > 0) {
+      void info.editor.putExternalContent({
+        type: 'files',
+        files,
+        point: info.point
+      })
+      return false
+    }
+
+    const textContent = getTextFromPasteEvent(info.event)
+    if (textContent) {
+      void info.editor.putExternalContent({
+        type: 'text',
+        ...textContent,
+        point: info.point
+      })
+      return false
+    }
+
+    return false
+  }
 }
 
 function CowartStylePanel(props) {
@@ -1428,6 +1497,7 @@ export default function App() {
         components={cowartComponents}
         shapeUtils={cowartShapeUtils}
         tools={[CowartAnnotationTool]}
+        options={cowartTldrawOptions}
       />
     </main>
   )


### PR DESCRIPTION
## Summary
- remove tldraw's paste keyboard shortcut bindings so Cmd+V can reach the browser native paste event instead of immediately calling navigator.clipboard.read()
- handle native paste events using ClipboardEvent.clipboardData only: files go through tldraw's existing external file handler, text goes through tldraw's text handler
- always stop the native paste path after Cowart handles the event so restricted in-app browsers do not fall back to navigator.clipboard.read()
- avoid clipboard permission failures for Cmd+V image paste in Codex Desktop / in-app browser contexts

## Verification
- npm run build
- git diff --check HEAD~1..HEAD
- Playwright runtime check with navigator.clipboard.read patched to throw NotAllowedError: Cmd/Ctrl+V produced 0 clipboard.read calls, synthetic image paste defaultPrevented=true, image shape count increased, final clipboard.read calls remained 0