### PR TITLE
feat(multiple-session-isolation): Add Cowart session isolation and stable startup port

### DIFF
--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -10,6 +10,9 @@ const TOOL_INSERT_IMAGE = "insert_cowart_image";
 const PAGE_ID_PREFIX = "page:";
 const PAGE_ASSETS_ROUTE = "/page-assets/";
 const CANVAS_FILE_NAME = "cowart-canvas.json";
+const SESSION_QUERY_PARAM = "sessionId";
+const SESSION_PAGE_ID_PREFIX = "cowart-session-";
+const SESSION_ID_MAX_LENGTH = 80;
 
 const JsonRpcError = {
   METHOD_NOT_FOUND: -32601,
@@ -36,6 +39,55 @@ function finiteNumber(value, fallback) {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
 
+// 统一处理工具参数里的 sessionId；空值保持旧的全局状态行为。
+function normalizeSessionId(value) {
+  if (typeof value !== "string") return null;
+  const sessionId = value.trim();
+  return sessionId.length > 0 ? sessionId : null;
+}
+
+// sessionId 会进入本地路径和 tldraw page id，只保留稳定安全的字符。
+function sanitizeSessionId(sessionId) {
+  return (
+    String(sessionId || "session")
+      .trim()
+      .replace(/[^a-zA-Z0-9_-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, SESSION_ID_MAX_LENGTH) || "session"
+  );
+}
+
+// 兼容浏览器 URL: /?sessionId=xxx 和 /sessionId=xxx。
+function sessionIdFromCowartUrl(value) {
+  const rawUrl = nonEmptyString(value);
+  if (!rawUrl) return null;
+
+  try {
+    const url = new URL(rawUrl);
+    const querySessionId = normalizeSessionId(url.searchParams.get(SESSION_QUERY_PARAM));
+    if (querySessionId) return querySessionId;
+
+    const pathMatch = /^\/sessionId=([^/]+)\/?$/.exec(url.pathname);
+    if (!pathMatch) return null;
+
+    try {
+      return normalizeSessionId(decodeURIComponent(pathMatch[1]));
+    } catch {
+      return normalizeSessionId(pathMatch[1]);
+    }
+  } catch {
+    return null;
+  }
+}
+
+function resolveSessionId(args = {}) {
+  return normalizeSessionId(args.sessionId) || sessionIdFromCowartUrl(args.cowartUrl);
+}
+
+function sessionStateDir(canvasDir, sessionId) {
+  return join(canvasDir, "sessions", sanitizeSessionId(sessionId));
+}
+
 function resolveCanvasDir(args = {}) {
   const explicitCanvasDir = nonEmptyString(args.canvasDir);
   if (explicitCanvasDir) return pathResolve(explicitCanvasDir);
@@ -57,15 +109,23 @@ function pathResolve(value) {
 }
 
 function resolveSelectionFile(args = {}) {
-  return join(resolveCanvasDir(args), "cowart-selection.json");
+  const canvasDir = resolveCanvasDir(args);
+  const sessionId = resolveSessionId(args);
+  return sessionId ? join(sessionStateDir(canvasDir, sessionId), "cowart-selection.json") : join(canvasDir, "cowart-selection.json");
 }
 
 function resolveViewStateFile(args = {}) {
-  return join(resolveCanvasDir(args), "cowart-view-state.json");
+  const canvasDir = resolveCanvasDir(args);
+  const sessionId = resolveSessionId(args);
+  return sessionId ? join(sessionStateDir(canvasDir, sessionId), "cowart-view-state.json") : join(canvasDir, "cowart-view-state.json");
 }
 
 function pageDirName(pageId) {
   return encodeURIComponent(pageId.replace(PAGE_ID_PREFIX, ""));
+}
+
+function sessionPageId(sessionId) {
+  return `${PAGE_ID_PREFIX}${SESSION_PAGE_ID_PREFIX}${sanitizeSessionId(sessionId)}`;
 }
 
 function pageAssetUrl(pageId, fileName) {
@@ -179,7 +239,22 @@ async function readViewState(args) {
 
 function normalizeCowartUrl(args = {}) {
   const value = nonEmptyString(args.cowartUrl) || nonEmptyString(process.env.COWART_URL) || "http://127.0.0.1:43217";
-  return value.replace(/\/+$/, "");
+  try {
+    const url = new URL(value);
+    if (url.pathname === "/" || /^\/sessionId=([^/]+)\/?$/.test(url.pathname)) {
+      return url.origin;
+    }
+    return `${url.origin}${url.pathname.replace(/\/+$/, "")}`;
+  } catch {
+    return value.replace(/\/+$/, "");
+  }
+}
+
+function cowartApiUrl(cowartUrl, args, apiPath) {
+  const url = new URL(apiPath, cowartUrl);
+  const sessionId = resolveSessionId(args);
+  if (sessionId) url.searchParams.set(SESSION_QUERY_PARAM, sessionId);
+  return url.toString();
 }
 
 async function fetchJson(url, options = {}) {
@@ -193,7 +268,7 @@ async function fetchJson(url, options = {}) {
 
 async function loadCanvasSnapshot(args) {
   const cowartUrl = normalizeCowartUrl(args);
-  const payload = await fetchJson(`${cowartUrl}/api/canvas`);
+  const payload = await fetchJson(cowartApiUrl(cowartUrl, args, "/api/canvas"));
   const snapshot = payload?.snapshot ?? payload;
   if (!snapshot || typeof snapshot !== "object" || !snapshot.schema || !snapshot.store) {
     throw new Error(`Expected Cowart canvas snapshot from ${cowartUrl}/api/canvas`);
@@ -201,8 +276,8 @@ async function loadCanvasSnapshot(args) {
   return { cowartUrl, snapshot, payload };
 }
 
-async function saveCanvasSnapshot(cowartUrl, snapshot) {
-  return fetchJson(`${cowartUrl}/api/canvas`, {
+async function saveCanvasSnapshot(cowartUrl, args, snapshot) {
+  return fetchJson(cowartApiUrl(cowartUrl, args, "/api/canvas"), {
     method: "PUT",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(snapshot),
@@ -297,6 +372,35 @@ function chooseIndex(store, parentId) {
   return generateKeyBetween(siblingIndexes.at(-1) ?? null, null);
 }
 
+// 当 session page 尚未由浏览器保存时，MCP 可在已有快照里补建这个 page。
+function choosePageIndex(store) {
+  const pageIndexes = Object.values(store)
+    .filter((record) => record?.typeName === "page" && typeof record.index === "string")
+    .map((record) => record.index)
+    .sort();
+  return generateKeyBetween(pageIndexes.at(-1) ?? null, null);
+}
+
+function sessionPageName(sessionId) {
+  const label = String(sessionId || "").trim() || sanitizeSessionId(sessionId);
+  return `Session ${label.slice(0, 48)}`;
+}
+
+function ensureSessionPageRecord(store, sessionId) {
+  const pageId = sessionPageId(sessionId);
+  if (store[pageId]) return { pageId, didCreate: false };
+
+  store[pageId] = {
+    meta: {},
+    id: pageId,
+    name: sessionPageName(sessionId),
+    index: choosePageIndex(store),
+    typeName: "page",
+  };
+
+  return { pageId, didCreate: true };
+}
+
 function firstSelectedShapeId(selection) {
   return selection?.selectedShapes?.length === 1 ? selection.selectedShapes[0]?.id : null;
 }
@@ -372,13 +476,21 @@ async function insertCowartImage(args = {}) {
   const store = snapshot.store;
   const { selection } = await readSelectionState(args);
   const viewState = await readViewState(args);
+  const sessionId = resolveSessionId(args);
 
   const anchorShapeId = nonEmptyString(args.anchorShapeId) || nonEmptyString(args.sourceShapeId) || firstSelectedShapeId(selection);
   const anchorShape = anchorShapeId ? getRecord(store, anchorShapeId, "anchor shape") : null;
+  const explicitPageId = nonEmptyString(args.pageId);
+  const viewStatePageId = nonEmptyString(viewState?.currentPageId);
+  const sessionPageResult =
+    sessionId && !explicitPageId && !anchorShape && (!viewStatePageId || !store[viewStatePageId])
+      ? ensureSessionPageRecord(store, sessionId)
+      : null;
   const pageId =
-    nonEmptyString(args.pageId) ||
+    explicitPageId ||
     (anchorShape ? findPageIdForShape(store, anchorShape.id) : null) ||
-    nonEmptyString(viewState?.currentPageId) ||
+    (viewStatePageId && store[viewStatePageId] ? viewStatePageId : null) ||
+    sessionPageResult?.pageId ||
     Object.values(store).find((record) => record?.typeName === "page")?.id;
   if (!pageId || !store[pageId]) throw new Error("Could not determine target pageId.");
 
@@ -461,11 +573,13 @@ async function insertCowartImage(args = {}) {
     await copyFile(sourceImagePath, filePath);
     store[assetId] = assetRecord;
     store[shapeId] = shapeRecord;
-    await saveCanvasSnapshot(cowartUrl, snapshot);
+    await saveCanvasSnapshot(cowartUrl, args, snapshot);
   }
 
   return {
     cowartUrl,
+    sessionId,
+    sessionPageCreated: Boolean(sessionPageResult?.didCreate),
     pageId,
     parentId,
     anchorShapeId,
@@ -499,6 +613,14 @@ function toolDefinitions() {
             type: "string",
             description: "Absolute canvas directory. If provided, this takes precedence over projectDir.",
           },
+          sessionId: {
+            type: "string",
+            description: "Optional Codex/Cowart session id. Reads canvas/sessions/<sessionId>/cowart-selection.json when provided.",
+          },
+          cowartUrl: {
+            type: "string",
+            description: "Optional Cowart browser URL. A sessionId in the URL is used when the explicit sessionId field is absent.",
+          },
         },
         additionalProperties: false,
       },
@@ -521,6 +643,10 @@ function toolDefinitions() {
           projectDir: { type: "string", description: "Absolute Cowart project directory containing canvas/." },
           canvasDir: { type: "string", description: "Absolute canvas directory. Overrides projectDir." },
           cowartUrl: { type: "string", description: "Running Cowart URL, for example http://127.0.0.1:43218." },
+          sessionId: {
+            type: "string",
+            description: "Optional Codex/Cowart session id. Uses that session's selection and view-state, and falls back to that session's page.",
+          },
           pageId: { type: "string", description: "Target tldraw page id. Optional when an anchor or view-state page is available." },
           anchorShapeId: { type: "string", description: "Existing shape id to place beside, usually the source image or AI frame." },
           sourceShapeId: { type: "string", description: "Alias for anchorShapeId." },

--- a/scripts/start-canvas.sh
+++ b/scripts/start-canvas.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CALLER_DIR="$PWD"
+HOST="${COWART_HOST:-127.0.0.1}"
 PORT="${COWART_PORT:-43217}"
 PROJECT_DIR="${COWART_PROJECT_DIR:-${1:-$CALLER_DIR}}"
 CANVAS_DIR="${COWART_CANVAS_DIR:-$PROJECT_DIR/canvas}"
@@ -12,11 +13,59 @@ export COWART_CANVAS_DIR="$CANVAS_DIR"
 
 cd "$ROOT_DIR"
 
+# 查找当前仓库已经启动的 Cowart Vite 服务，避免同一画布重复开多个进程。
+find_existing_cowart_pids() {
+  pgrep -f "$ROOT_DIR/node_modules/.bin/vite" 2>/dev/null || true
+}
+
+# 打印已运行 Cowart 服务的真实监听地址，输出给调用方直接复用。
+print_listening_addresses_for_pids() {
+  for pid in "$@"; do
+    lsof -nP -a -p "$pid" -iTCP -sTCP:LISTEN 2>/dev/null | awk 'NR > 1 { print $9 }'
+  done
+}
+
+# 打印占用端口的进程信息，便于判断该停止哪个旧进程。
+print_processes_for_pids() {
+  local pid_list
+  pid_list="$(IFS=,; echo "$*")"
+  ps -p "$pid_list" -o pid=,command= 2>/dev/null || true
+}
+
 if [ ! -d node_modules ] || [ ! -x node_modules/.bin/vite ]; then
   npm install
 fi
 
-echo "Cowart canvas: http://127.0.0.1:${PORT}"
+EXISTING_COWART_PIDS=()
+while IFS= read -r pid; do
+  if [ -n "$pid" ]; then
+    EXISTING_COWART_PIDS+=("$pid")
+  fi
+done < <(find_existing_cowart_pids)
+if [ "${#EXISTING_COWART_PIDS[@]}" -gt 0 ]; then
+  echo "Cowart canvas is already running:"
+  print_listening_addresses_for_pids "${EXISTING_COWART_PIDS[@]}" | sed 's#^#  http://#'
+  echo "Cowart process:"
+  print_processes_for_pids "${EXISTING_COWART_PIDS[@]}"
+  exit 0
+fi
+
+# 端口被其他进程占用时直接失败；禁止 Vite 自动切到 43218/43219 造成 URL 混乱。
+PORT_OWNER_PIDS=()
+while IFS= read -r pid; do
+  if [ -n "$pid" ]; then
+    PORT_OWNER_PIDS+=("$pid")
+  fi
+done < <(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null || true)
+if [ "${#PORT_OWNER_PIDS[@]}" -gt 0 ]; then
+  echo "Cowart canvas port ${HOST}:${PORT} is already in use." >&2
+  echo "Refusing to start on a fallback port because that makes the canvas URL ambiguous." >&2
+  echo "Port owner:" >&2
+  print_processes_for_pids "${PORT_OWNER_PIDS[@]}" >&2
+  exit 1
+fi
+
+echo "Cowart canvas: http://${HOST}:${PORT}"
 echo "Cowart canvas data: ${CANVAS_DIR}/pages/<page-id>/cowart-canvas.json"
-echo "Cowart page assets: ${CANVAS_DIR}/pages/<page-id>/assets -> http://127.0.0.1:${PORT}/page-assets/<page-id>/"
-exec npm run dev -- --host 127.0.0.1 --port "$PORT"
+echo "Cowart page assets: ${CANVAS_DIR}/pages/<page-id>/assets -> http://${HOST}:${PORT}/page-assets/<page-id>/"
+exec npm run dev -- --host "$HOST" --port "$PORT" --strictPort

--- a/skills/cowart-image-edit/SKILL.md
+++ b/skills/cowart-image-edit/SKILL.md
@@ -15,6 +15,13 @@ The Cowart service should be running for the active project, usually at:
 http://127.0.0.1:43217
 ```
 
+If the current Cowart browser URL contains `sessionId`, keep using that same
+session for all Cowart MCP or API calls. Prefer the query-string form:
+
+```text
+http://127.0.0.1:43217/?sessionId=<codex-thread-id>
+```
+
 The user is responsible for providing the relevant screenshot(s). Do not auto-capture the current canvas and do not scan the whole canvas to infer edit requests; a canvas may contain many images with different annotations.
 
 ## Workflow
@@ -118,6 +125,7 @@ The user is responsible for providing the relevant screenshot(s). Do not auto-ca
      "imagePath": "/absolute/path/to/annotation-edit-20260620-153012.png",
      "projectDir": "/absolute/path/to/user/codex-project",
      "cowartUrl": "http://127.0.0.1:43217",
+     "sessionId": "<codex-thread-id>",
      "anchorShapeId": "<selected source image or frame id>",
      "placement": "right",
      "margin": 40,
@@ -132,7 +140,9 @@ The user is responsible for providing the relevant screenshot(s). Do not auto-ca
    ```
 
    If the running Cowart service uses a Vite fallback port, pass the actual
-   browser URL such as `http://127.0.0.1:43218` as `cowartUrl`.
+   browser URL such as `http://127.0.0.1:43218` as `cowartUrl`. If the browser
+   URL has `sessionId`, pass that value separately as `sessionId` or keep it in
+   `cowartUrl`.
 
    The MCP tool must return the new `assetId`, `shapeId`, saved asset path,
    page id, bounds, and generated `index`. Confirm that the returned `index` is

--- a/skills/cowart-image-gen/SKILL.md
+++ b/skills/cowart-image-gen/SKILL.md
@@ -15,6 +15,13 @@ The Cowart service should be running for the user's active project, usually at:
 http://127.0.0.1:43217
 ```
 
+If the current Cowart browser URL contains `sessionId`, keep using that same
+session for every API or MCP call. Prefer the query-string form:
+
+```text
+http://127.0.0.1:43217/?sessionId=<codex-thread-id>
+```
+
 New holders are tldraw `frame` shapes with:
 
 ```json
@@ -37,7 +44,13 @@ meta flag. Support both shapes.
    curl -s http://127.0.0.1:43217/api/selection
    ```
 
-   You can also use the Cowart MCP `get_cowart_selection` tool if it is available.
+   If working inside a session URL, include the same session:
+
+   ```bash
+   curl -s 'http://127.0.0.1:43217/api/selection?sessionId=<codex-thread-id>'
+   ```
+
+   You can also use the Cowart MCP `get_cowart_selection` tool if it is available. Pass `sessionId` when the canvas URL has one.
 
 2. Check whether exactly one selected shape is an AI image holder. A holder is any selected shape with either:
 
@@ -133,6 +146,8 @@ meta flag. Support both shapes.
    ```bash
    curl -s http://127.0.0.1:43217/api/canvas
    ```
+
+   If working inside a session URL, include the same `sessionId` in API calls or pass it to Cowart MCP tools. This keeps standalone insertions on that session's current/default page instead of the legacy global page.
 
    Prefer page-local asset URLs in the image asset:
 

--- a/skills/cowart-open-canvas/SKILL.md
+++ b/skills/cowart-open-canvas/SKILL.md
@@ -19,6 +19,14 @@ Run this from the Cowart repository root. Use the active workspace or project di
 
 The default URL is `http://127.0.0.1:43217/`. If the service output prints a different `Local:` URL, open that actual URL instead.
 
+When a stable Codex thread/session id is available, open the canvas with `?sessionId=<id>` appended, for example:
+
+```text
+http://127.0.0.1:43217/?sessionId=<codex-thread-id>
+```
+
+Use a different `sessionId` for each Codex conversation. This makes the first opened Cowart page, view state, and selection state session-scoped while keeping all pages visible in the same tldraw document. The service also accepts `/sessionId=<id>` for compatibility, but the query-string form is preferred.
+
 Use the Browser plugin's `control-in-app-browser` skill as the source of truth for opening the in-app browser. The correct model-side flow is:
 
 1. Use tool discovery for the Node REPL JavaScript execution tool if it is not already visible. The required callable tool is the `js` execution tool, commonly exposed as `mcp__node_repl__js`; `js_reset` and `js_add_node_module_dir` are not sufficient for browser control.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import {
   LineToolbarItem,
   NoteToolbarItem,
   OvalToolbarItem,
+  PageRecordType,
   RectangleToolbarItem,
   RhombusToolbarItem,
   SelectToolbarItem,
@@ -56,6 +57,10 @@ const CANVAS_ENDPOINT = '/api/canvas'
 const CANVAS_EVENTS_ENDPOINT = '/api/canvas-events'
 const SELECTION_ENDPOINT = '/api/selection'
 const VIEW_STATE_ENDPOINT = '/api/view-state'
+const SESSION_QUERY_PARAM = 'sessionId'
+const SESSION_PATH_PATTERN = /^\/sessionId=([^/]+)\/?$/
+const SESSION_PAGE_ID_PREFIX = 'cowart-session-'
+const SESSION_ID_MAX_LENGTH = 80
 const SELECTION_STATE_ELEMENT_ID = 'cowart-selection-state'
 const AI_IMAGE_TOOL_ID = 'ai-image'
 const AI_IMAGE_HOLDER_LABEL = 'AI 图片'
@@ -89,6 +94,97 @@ const annotationToolIcon = (
     dangerouslySetInnerHTML={{ __html: annotationToolIconSvg }}
   />
 )
+
+// 归一化 URL 或工具参数里的 sessionId，空值继续走旧的全局状态。
+function normalizeCowartSessionId(value) {
+  if (typeof value !== 'string') return null
+  const sessionId = value.trim()
+  return sessionId.length > 0 ? sessionId : null
+}
+
+// 兼容标准 query 写法和用户已经试过的 /sessionId=xxx 路径写法。
+function getCowartSessionIdFromLocation(location) {
+  const querySessionId = normalizeCowartSessionId(
+    new URLSearchParams(location.search).get(SESSION_QUERY_PARAM)
+  )
+  if (querySessionId) return querySessionId
+
+  const pathMatch = SESSION_PATH_PATTERN.exec(location.pathname)
+  if (!pathMatch) return null
+
+  try {
+    return normalizeCowartSessionId(decodeURIComponent(pathMatch[1]))
+  } catch {
+    return normalizeCowartSessionId(pathMatch[1])
+  }
+}
+
+// React 初始化时读取一次，避免渲染期间 URL 状态抖动。
+function getCowartSessionIdFromCurrentUrl() {
+  if (typeof window === 'undefined') return null
+  return getCowartSessionIdFromLocation(window.location)
+}
+
+// sessionId 会落到 tldraw page id 和本地目录名里，必须收敛到稳定安全的片段。
+function sanitizeCowartSessionId(sessionId) {
+  return (
+    String(sessionId || 'session')
+      .trim()
+      .replace(/[^a-zA-Z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, SESSION_ID_MAX_LENGTH) || 'session'
+  )
+}
+
+// 每个 Codex session 都有一个稳定首页 page，首次打开不会再抢默认 Page 1。
+function getCowartSessionPageId(sessionId) {
+  return PageRecordType.createId(`${SESSION_PAGE_ID_PREFIX}${sanitizeCowartSessionId(sessionId)}`)
+}
+
+// page 菜单里展示短名称，完整隔离依赖 page id 而不是展示名。
+function getCowartSessionPageName(sessionId) {
+  const label = String(sessionId || '').trim() || sanitizeCowartSessionId(sessionId)
+  return `Session ${label.slice(0, 48)}`
+}
+
+// 所有浏览器端 API 请求都显式携带 sessionId，让服务端选中对应状态文件。
+function getCowartApiEndpoint(endpoint, sessionId) {
+  if (!sessionId || typeof window === 'undefined') return endpoint
+  const url = new URL(endpoint, window.location.origin)
+  url.searchParams.set(SESSION_QUERY_PARAM, sessionId)
+  return `${url.pathname}${url.search}`
+}
+
+// 确保 session 首页存在；如果该 session 曾手动切过 page，则尊重已保存的 view state。
+function ensureCowartSessionPage(editor, sessionId, savedViewState) {
+  if (!sessionId) {
+    restoreCowartViewState(editor, savedViewState)
+    return false
+  }
+
+  const sessionPageId = getCowartSessionPageId(sessionId)
+  let didChangeDocument = false
+
+  if (!editor.getPage(sessionPageId)) {
+    editor.createPage({
+      id: sessionPageId,
+      name: getCowartSessionPageName(sessionId)
+    })
+    didChangeDocument = true
+  }
+
+  const savedPageId = savedViewState?.currentPageId
+  if (savedPageId && editor.getPage(savedPageId)) {
+    restoreCowartViewState(editor, savedViewState)
+    return didChangeDocument
+  }
+
+  if (editor.getCurrentPageId() !== sessionPageId) {
+    editor.setCurrentPage(sessionPageId)
+  }
+
+  return didChangeDocument
+}
 
 function recordsAreEqual(left, right) {
   return JSON.stringify(left) === JSON.stringify(right)
@@ -985,10 +1081,15 @@ function writeCowartSelectionState(selectionSnapshot) {
 }
 
 export default function App() {
+  const [sessionId] = useState(() => getCowartSessionIdFromCurrentUrl())
   const [snapshot, setSnapshot] = useState()
   const [viewState, setViewState] = useState()
   const [loadError, setLoadError] = useState(null)
   const [skippedRecords, setSkippedRecords] = useState([])
+  const canvasEndpoint = getCowartApiEndpoint(CANVAS_ENDPOINT, sessionId)
+  const canvasEventsEndpoint = getCowartApiEndpoint(CANVAS_EVENTS_ENDPOINT, sessionId)
+  const selectionEndpoint = getCowartApiEndpoint(SELECTION_ENDPOINT, sessionId)
+  const viewStateEndpoint = getCowartApiEndpoint(VIEW_STATE_ENDPOINT, sessionId)
 
   useEffect(() => {
     const controller = new AbortController()
@@ -996,8 +1097,8 @@ export default function App() {
     async function loadCanvas() {
       try {
         const [canvasResponse, viewStateResponse] = await Promise.all([
-          fetch(CANVAS_ENDPOINT, { signal: controller.signal }),
-          fetch(VIEW_STATE_ENDPOINT, { signal: controller.signal })
+          fetch(canvasEndpoint, { signal: controller.signal }),
+          fetch(viewStateEndpoint, { signal: controller.signal })
         ])
         if (!canvasResponse.ok) {
           throw new Error(`Failed to load canvas: ${canvasResponse.status} - ${canvasResponse.statusText}`)
@@ -1024,22 +1125,20 @@ export default function App() {
     loadCanvas()
 
     return () => controller.abort()
-  }, [])
+  }, [canvasEndpoint, viewStateEndpoint])
 
   const handleMount = useCallback((editor) => {
     window.__cowartEditor = editor
     window.__cowartSelection = () => getCowartSelection(editor)
     window.__cowartViewState = () => getCowartViewState(editor)
+    window.__cowartSessionId = sessionId
+    window.__cowartSessionPageId = sessionId ? getCowartSessionPageId(sessionId) : null
     let lastSyncedSelectionState = ''
     let isSelectionStateSaving = false
     let hasPendingSelectionState = false
     let lastSyncedViewState = ''
     let isViewStateSaving = false
     let hasPendingViewState = false
-
-    editor.timers.requestAnimationFrame(() => {
-      restoreCowartViewState(editor, viewState)
-    })
 
     async function syncSelectionState() {
       const selectionSnapshot = getCowartSelectionSnapshot(editor)
@@ -1056,7 +1155,7 @@ export default function App() {
 
       isSelectionStateSaving = true
       try {
-        const response = await fetch(SELECTION_ENDPOINT, {
+        const response = await fetch(selectionEndpoint, {
           method: 'PUT',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify({
@@ -1098,7 +1197,7 @@ export default function App() {
 
       isViewStateSaving = true
       try {
-        const response = await fetch(VIEW_STATE_ENDPOINT, {
+        const response = await fetch(viewStateEndpoint, {
           method: 'PUT',
           headers: { 'content-type': 'application/json' },
           body: nextViewState
@@ -1138,7 +1237,7 @@ export default function App() {
       isSaving = true
       try {
         const body = JSON.stringify(editor.store.getStoreSnapshot())
-        const response = await fetch(CANVAS_ENDPOINT, {
+        const response = await fetch(canvasEndpoint, {
           method: 'PUT',
           headers: { 'content-type': 'application/json' },
           body
@@ -1164,6 +1263,12 @@ export default function App() {
       saveTimer = window.setTimeout(saveCanvas, 500)
     }
 
+    editor.timers.requestAnimationFrame(() => {
+      const didCreateSessionPage = ensureCowartSessionPage(editor, sessionId, viewState)
+      if (didCreateSessionPage) scheduleSave()
+      syncViewState()
+    })
+
     async function loadRemoteCanvasSnapshot() {
       remoteLoadController?.abort()
       const controller = new AbortController()
@@ -1173,7 +1278,7 @@ export default function App() {
       const preFetchStore = preserveLocalChanges ? null : editor.store.getStoreSnapshot().store
 
       try {
-        const response = await fetch(CANVAS_ENDPOINT, { signal: controller.signal })
+        const response = await fetch(canvasEndpoint, { signal: controller.signal })
         if (!response.ok) {
           throw new Error(`Failed to refresh canvas: ${response.status}`)
         }
@@ -1215,7 +1320,7 @@ export default function App() {
 
     let canvasEvents = null
     if ('EventSource' in window) {
-      canvasEvents = new EventSource(CANVAS_EVENTS_ENDPOINT)
+      canvasEvents = new EventSource(canvasEventsEndpoint)
       canvasEvents.addEventListener('canvas-changed', loadRemoteCanvasSnapshot)
       canvasEvents.onerror = (error) => {
         console.warn('Cowart canvas live refresh disconnected.', error)
@@ -1296,6 +1401,8 @@ export default function App() {
         delete window.__cowartEditor
         delete window.__cowartSelection
         delete window.__cowartViewState
+        delete window.__cowartSessionId
+        delete window.__cowartSessionPageId
       }
       document.getElementById(SELECTION_STATE_ELEMENT_ID)?.remove()
       unsubscribe()
@@ -1304,7 +1411,7 @@ export default function App() {
       syncViewState()
       saveCanvas()
     }
-  }, [viewState])
+  }, [canvasEndpoint, canvasEventsEndpoint, selectionEndpoint, sessionId, viewState, viewStateEndpoint])
 
   if (snapshot === undefined || viewState === undefined) {
     return (

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,9 +12,13 @@ const selectionFile = join(canvasDir, 'cowart-selection.json')
 const viewStateFile = join(canvasDir, 'cowart-view-state.json')
 const canvasPagesDir = join(canvasDir, 'pages')
 const canvasAssetsDir = join(canvasDir, 'assets')
+const canvasSessionsDir = join(canvasDir, 'sessions')
 const pagesManifestFile = join(canvasPagesDir, 'manifest.json')
 const canvasFileName = 'cowart-canvas.json'
 const pageIdPrefix = 'page:'
+const sessionQueryParam = 'sessionId'
+const sessionPageIdPrefix = 'cowart-session-'
+const sessionIdMaxLength = 80
 const globalAssetsRoute = '/assets/'
 const pageAssetsRoute = '/page-assets/'
 const canvasEventClients = new Set()
@@ -112,6 +116,56 @@ function isViewState(value) {
     isFiniteNumber(value.camera.y) &&
     isFiniteNumber(value.camera.z)
   )
+}
+
+// 将请求里的 sessionId 收敛为空或稳定字符串，空值继续使用旧全局文件。
+function normalizeSessionId(value) {
+  if (typeof value !== 'string') return null
+  const sessionId = value.trim()
+  return sessionId.length > 0 ? sessionId : null
+}
+
+// sessionId 会进入本地路径和 page id，只保留稳定安全的字符。
+function sanitizeSessionId(sessionId) {
+  return (
+    String(sessionId || 'session')
+      .trim()
+      .replace(/[^a-zA-Z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, sessionIdMaxLength) || 'session'
+  )
+}
+
+// 从 API 请求 query 中取 sessionId；浏览器端会显式追加这个参数。
+function getRequestSessionId(req) {
+  const url = new URL(req.url, 'http://127.0.0.1')
+  return normalizeSessionId(url.searchParams.get(sessionQueryParam))
+}
+
+// 每个 session 的 selection/view-state 单独落盘，避免多个 Codex 会话互相覆盖。
+function sessionStateDir(sessionId) {
+  return join(canvasSessionsDir, sanitizeSessionId(sessionId))
+}
+
+function selectionFileForSession(sessionId) {
+  return sessionId ? join(sessionStateDir(sessionId), 'cowart-selection.json') : selectionFile
+}
+
+function viewStateFileForSession(sessionId) {
+  return sessionId ? join(sessionStateDir(sessionId), 'cowart-view-state.json') : viewStateFile
+}
+
+function sessionPageId(sessionId) {
+  return `${pageIdPrefix}${sessionPageIdPrefix}${sanitizeSessionId(sessionId)}`
+}
+
+function defaultViewState(sessionId) {
+  return {
+    version: 1,
+    currentPageId: sessionId ? sessionPageId(sessionId) : null,
+    camera: { x: 0, y: 0, z: 1 },
+    updatedAt: null
+  }
 }
 
 function isSafeChildPath(parent, child) {
@@ -486,17 +540,22 @@ function canvasStoragePlugin() {
 
       server.middlewares.use('/api/selection', async (req, res) => {
         try {
+          const sessionId = getRequestSessionId(req)
+          const stateFile = selectionFileForSession(sessionId)
+
           if (req.method === 'GET') {
             try {
               sendJson(res, 200, {
-                selection: await readJsonFile(selectionFile),
-                path: selectionFile
+                selection: await readJsonFile(stateFile),
+                path: stateFile,
+                sessionId
               })
             } catch (error) {
               if (error.code === 'ENOENT') {
                 sendJson(res, 200, {
                   selection: { selectedShapes: [], updatedAt: null },
-                  path: selectionFile
+                  path: stateFile,
+                  sessionId
                 })
                 return
               }
@@ -513,8 +572,8 @@ function canvasStoragePlugin() {
               return
             }
 
-            await writeJsonAtomic(selectionFile, selection)
-            sendJson(res, 200, { ok: true, path: selectionFile })
+            await writeJsonAtomic(stateFile, selection)
+            sendJson(res, 200, { ok: true, path: stateFile, sessionId })
             return
           }
 
@@ -528,22 +587,22 @@ function canvasStoragePlugin() {
 
       server.middlewares.use('/api/view-state', async (req, res) => {
         try {
+          const sessionId = getRequestSessionId(req)
+          const stateFile = viewStateFileForSession(sessionId)
+
           if (req.method === 'GET') {
             try {
               sendJson(res, 200, {
-                viewState: await readJsonFile(viewStateFile),
-                path: viewStateFile
+                viewState: await readJsonFile(stateFile),
+                path: stateFile,
+                sessionId
               })
             } catch (error) {
               if (error.code === 'ENOENT') {
                 sendJson(res, 200, {
-                  viewState: {
-                    version: 1,
-                    currentPageId: null,
-                    camera: { x: 0, y: 0, z: 1 },
-                    updatedAt: null
-                  },
-                  path: viewStateFile
+                  viewState: defaultViewState(sessionId),
+                  path: stateFile,
+                  sessionId
                 })
                 return
               }
@@ -560,8 +619,8 @@ function canvasStoragePlugin() {
               return
             }
 
-            await writeJsonAtomic(viewStateFile, viewState)
-            sendJson(res, 200, { ok: true, path: viewStateFile })
+            await writeJsonAtomic(stateFile, viewState)
+            sendJson(res, 200, { ok: true, path: stateFile, sessionId })
             return
           }
 


### PR DESCRIPTION
## Summary

- Add `sessionId` support so Cowart browser sessions get isolated page, selection, and view-state records.
- Propagate session-aware API URLs through the React app, Vite storage endpoints, and Cowart MCP image insertion.
- Keep `scripts/start-canvas.sh` on a stable local port by reusing an existing Cowart service, refusing ambiguous fallback ports, and starting Vite with `--strictPort`.
- Update Cowart skills so agents preserve the current session when opening canvases, generating images, and applying annotation edits.

## Root cause

Cowart previously reused global canvas selection/view-state and default page behavior across Codex conversations. When multiple sessions used the same local Cowart service, one session could read or overwrite another session's selected shapes, page view, or standalone image insertion target.

The canvas startup script also passed only `--port 43217` to Vite. If that port was temporarily occupied, Vite silently moved to `43218` or `43219`, while the script still printed the default URL. That made it easy to open the wrong canvas URL or accidentally leave multiple services running.

## Impact

Each Codex conversation can now open Cowart with a stable `?sessionId=<id>` URL. The first open creates or selects a session-specific page, while legacy URLs without `sessionId` keep the existing global behavior.

Local canvas startup is also predictable: by default it stays on `http://127.0.0.1:43217/`, reports an already-running Cowart service instead of starting another one, and fails loudly if a different process owns the requested port.

## Validation

- `bash -n scripts/start-canvas.sh`
- `git diff --check`
- Vite build through the Node API on the current branch; build completed successfully with only the existing large-chunk warning.
- Duplicate startup check: `./scripts/start-canvas.sh /Users/wenren/code/github_fork` reported the existing Cowart service at `http://127.0.0.1:43217` instead of starting another service.
- Port checks:
  - `lsof -nP -iTCP:43217 -sTCP:LISTEN` showed Cowart listening on `127.0.0.1:43217`
  - `lsof -nP -iTCP:43218 -sTCP:LISTEN` found no listener
- Session API smoke test against local Cowart service on `127.0.0.1:43217`:
  - `/api/selection?sessionId=codex-pr-update-verify-20260625` writes and reads from `canvas/sessions/codex-pr-update-verify-20260625/`
  - `/api/view-state?sessionId=codex-pr-update-verify-20260625` returns `page:cowart-session-codex-pr-update-verify-20260625`
  - `/api/canvas?sessionId=codex-pr-update-verify-20260625` returns a valid tldraw store snapshot
