### PR TITLE
feat: 新增画布设置与对象属性编辑面板

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2363,9 +2363,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2378,9 +2375,6 @@
       "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2395,9 +2389,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2410,9 +2401,6 @@
       "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2427,9 +2415,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2442,9 +2427,6 @@
       "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2459,9 +2441,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2474,9 +2453,6 @@
       "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2491,9 +2467,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2506,9 +2479,6 @@
       "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2523,9 +2493,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2539,9 +2506,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2554,9 +2518,6 @@
       "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -49,6 +49,7 @@ import annotationToolIconRaw from './assets/tool-comment.svg?raw'
 import CowartInspector from './components/CowartInspector.jsx'
 import { CowartImageShapeUtil } from './components/CowartImageShapeUtil.jsx'
 import { isCanvasSnapshot, sanitizeCanvasSnapshotForTldraw } from './canvasSnapshot.js'
+import { CowartNoteShapeUtil, CowartTextShapeUtil } from './components/CowartTextShapeUtils.jsx'
 
 const CANVAS_ENDPOINT = '/api/canvas'
 const CANVAS_EVENTS_ENDPOINT = '/api/canvas-events'
@@ -709,7 +710,12 @@ class CowartFrameShapeUtil extends FrameShapeUtil {
   }
 }
 
-const cowartShapeUtils = [CowartFrameShapeUtil, CowartImageShapeUtil]
+const cowartShapeUtils = [
+  CowartFrameShapeUtil,
+  CowartImageShapeUtil,
+  CowartTextShapeUtil,
+  CowartNoteShapeUtil
+]
 
 const cowartUiOverrides = {
   translations: {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,18 +44,17 @@ import {
 } from 'tldraw'
 import { AllSelection } from '@tiptap/pm/state'
 import 'tldraw/tldraw.css'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import annotationToolIconRaw from './assets/tool-comment.svg?raw'
-import {
-  describeSkippedRecord,
-  isCanvasSnapshot,
-  sanitizeCanvasSnapshotForTldraw
-} from './canvasSnapshot.js'
+import CowartInspector from './components/CowartInspector.jsx'
+import { CowartImageShapeUtil } from './components/CowartImageShapeUtil.jsx'
+import { isCanvasSnapshot, sanitizeCanvasSnapshotForTldraw } from './canvasSnapshot.js'
 
 const CANVAS_ENDPOINT = '/api/canvas'
 const CANVAS_EVENTS_ENDPOINT = '/api/canvas-events'
 const SELECTION_ENDPOINT = '/api/selection'
 const VIEW_STATE_ENDPOINT = '/api/view-state'
+const SETTINGS_ENDPOINT = '/api/settings'
 const SELECTION_STATE_ELEMENT_ID = 'cowart-selection-state'
 const AI_IMAGE_TOOL_ID = 'ai-image'
 const AI_IMAGE_HOLDER_LABEL = 'AI 图片'
@@ -82,6 +81,39 @@ const ANNOTATION_MAX_BEND = 48
 const ANNOTATION_LABEL_POSITION = 0
 const ANNOTATION_SELECT_TEXT_MAX_ATTEMPTS = 8
 const ANNOTATION_SELECT_TEXT_SETTLE_ATTEMPTS = 4
+const DEFAULT_CANVAS_SETTINGS = {
+  version: 1,
+  backgroundColor: '#f7f5ef',
+  showGrid: false,
+  aiImageHolderWidth: AI_IMAGE_HOLDER_DEFAULT_W,
+  aiImageHolderHeight: AI_IMAGE_HOLDER_DEFAULT_H,
+  annotationColor: ANNOTATION_DEFAULT_COLOR
+}
+const ANNOTATION_COLOR_OPTIONS = [
+  { value: 'red', label: '红色', swatch: '#e5484d' },
+  { value: 'orange', label: '橙色', swatch: '#f76b15' },
+  { value: 'yellow', label: '黄色', swatch: '#f5d90a' },
+  { value: 'green', label: '绿色', swatch: '#30a46c' },
+  { value: 'blue', label: '蓝色', swatch: '#3e63dd' },
+  { value: 'violet', label: '紫色', swatch: '#7c3aed' },
+  { value: 'black', label: '黑色', swatch: '#1f2430' },
+  { value: 'grey', label: '灰色', swatch: '#697386' }
+]
+const TL_COLOR_OPTIONS = [
+  { value: 'black', swatch: '#1f2430' },
+  { value: 'grey', swatch: '#697386' },
+  { value: 'light-violet', swatch: '#b8a3ff' },
+  { value: 'violet', swatch: '#7c3aed' },
+  { value: 'blue', swatch: '#3e63dd' },
+  { value: 'light-blue', swatch: '#8ec5ff' },
+  { value: 'yellow', swatch: '#f5d90a' },
+  { value: 'orange', swatch: '#f76b15' },
+  { value: 'green', swatch: '#30a46c' },
+  { value: 'light-green', swatch: '#8fd19e' },
+  { value: 'light-red', swatch: '#f39aa0' },
+  { value: 'red', swatch: '#e5484d' },
+  { value: 'white', swatch: '#ffffff' }
+]
 const annotationToolIconSvg = annotationToolIconRaw.replaceAll('black', 'currentColor')
 const annotationToolIcon = (
   <div
@@ -89,6 +121,150 @@ const annotationToolIcon = (
     dangerouslySetInnerHTML={{ __html: annotationToolIconSvg }}
   />
 )
+
+function clampNumber(value, min, max, fallback) {
+  const number = Number(value)
+  if (!Number.isFinite(number)) return fallback
+  return Math.min(Math.max(Math.round(number), min), max)
+}
+
+function normalizeHexColor(value) {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim().replace(/^#/, '')
+
+  if (/^[0-9a-fA-F]{3}$/.test(normalized)) {
+    return `#${normalized
+      .split('')
+      .map((char) => char + char)
+      .join('')
+      .toLowerCase()}`
+  }
+
+  if (/^[0-9a-fA-F]{6}$/.test(normalized)) {
+    return `#${normalized.toLowerCase()}`
+  }
+
+  return null
+}
+
+function hexToRgb(value) {
+  const normalized = normalizeHexColor(value)
+  if (!normalized) return null
+
+  return {
+    r: Number.parseInt(normalized.slice(1, 3), 16),
+    g: Number.parseInt(normalized.slice(3, 5), 16),
+    b: Number.parseInt(normalized.slice(5, 7), 16)
+  }
+}
+
+function resolveTldrawColor(value, fallback = 'black') {
+  if (TL_COLOR_OPTIONS.some((option) => option.value === value)) {
+    return value
+  }
+
+  const targetColor = hexToRgb(value)
+  if (!targetColor) return fallback
+
+  let closestOption = TL_COLOR_OPTIONS.find((option) => option.value === fallback) ?? TL_COLOR_OPTIONS[0]
+  let closestDistance = Number.POSITIVE_INFINITY
+
+  for (const option of TL_COLOR_OPTIONS) {
+    const optionColor = hexToRgb(option.swatch)
+    if (!optionColor) continue
+
+    const distance =
+      (targetColor.r - optionColor.r) ** 2 +
+      (targetColor.g - optionColor.g) ** 2 +
+      (targetColor.b - optionColor.b) ** 2
+
+    if (distance < closestDistance) {
+      closestOption = option
+      closestDistance = distance
+    }
+  }
+
+  return closestOption?.value ?? fallback
+}
+
+function sanitizeShapeRecordColors(record) {
+  if (record?.typeName !== 'shape' || !record.props || typeof record.props !== 'object') {
+    return record
+  }
+
+  let nextProps = record.props
+  let didChange = false
+
+  if (typeof record.props.color === 'string') {
+    const resolvedColor = resolveTldrawColor(record.props.color, 'black')
+    if (resolvedColor !== record.props.color) {
+      nextProps = { ...nextProps, color: resolvedColor }
+      didChange = true
+    }
+  }
+
+  if (typeof record.props.labelColor === 'string') {
+    const fallbackLabelColor = typeof nextProps.color === 'string' ? nextProps.color : 'black'
+    const resolvedLabelColor = resolveTldrawColor(record.props.labelColor, fallbackLabelColor)
+    if (resolvedLabelColor !== record.props.labelColor) {
+      nextProps = { ...nextProps, labelColor: resolvedLabelColor }
+      didChange = true
+    }
+  }
+
+  return didChange ? { ...record, props: nextProps } : record
+}
+
+function sanitizeCanvasSnapshot(snapshot) {
+  if (!isCanvasSnapshot(snapshot)) return snapshot
+
+  let didChange = false
+  const nextStore = {}
+
+  for (const [id, record] of Object.entries(snapshot.store)) {
+    const nextRecord = sanitizeShapeRecordColors(record)
+    nextStore[id] = nextRecord
+    if (nextRecord !== record) {
+      didChange = true
+    }
+  }
+
+  return didChange ? { ...snapshot, store: nextStore } : snapshot
+}
+
+function normalizeCanvasSettings(settings) {
+  const source = settings && typeof settings === 'object' ? settings : {}
+  const backgroundColor =
+    typeof source.backgroundColor === 'string' && /^#[0-9a-fA-F]{6}$/.test(source.backgroundColor)
+      ? source.backgroundColor
+      : DEFAULT_CANVAS_SETTINGS.backgroundColor
+  const annotationColor = ANNOTATION_COLOR_OPTIONS.some((option) => option.value === source.annotationColor)
+    ? source.annotationColor
+    : DEFAULT_CANVAS_SETTINGS.annotationColor
+
+  return {
+    ...DEFAULT_CANVAS_SETTINGS,
+    backgroundColor,
+    showGrid: Boolean(source.showGrid),
+    aiImageHolderWidth: clampNumber(
+      source.aiImageHolderWidth,
+      80,
+      2400,
+      DEFAULT_CANVAS_SETTINGS.aiImageHolderWidth
+    ),
+    aiImageHolderHeight: clampNumber(
+      source.aiImageHolderHeight,
+      80,
+      2400,
+      DEFAULT_CANVAS_SETTINGS.aiImageHolderHeight
+    ),
+    annotationColor
+  }
+}
+
+function getActiveCanvasSettings() {
+  return normalizeCanvasSettings(window.__cowartSettings)
+}
 
 function recordsAreEqual(left, right) {
   return JSON.stringify(left) === JSON.stringify(right)
@@ -205,6 +381,7 @@ function getAspectIconStyle(preset) {
 
 function createAiImageHolderShape(editor, id, shapeOverrides = {}) {
   const scale = editor.getResizeScaleFactor()
+  const settings = getActiveCanvasSettings()
   const { meta, props, ...shapeRecordOverrides } = shapeOverrides
   const { scale: _scale, ...frameProps } = props ?? {}
 
@@ -217,8 +394,8 @@ function createAiImageHolderShape(editor, id, shapeOverrides = {}) {
       ...meta
     },
     props: {
-      w: AI_IMAGE_HOLDER_DEFAULT_W * scale,
-      h: AI_IMAGE_HOLDER_DEFAULT_H * scale,
+      w: settings.aiImageHolderWidth * scale,
+      h: settings.aiImageHolderHeight * scale,
       name: AI_IMAGE_HOLDER_LABEL,
       color: 'blue',
       ...frameProps
@@ -228,8 +405,9 @@ function createAiImageHolderShape(editor, id, shapeOverrides = {}) {
 
 function createAiImageHolderAtViewportCenter(editor) {
   const scale = editor.getResizeScaleFactor()
-  const w = AI_IMAGE_HOLDER_DEFAULT_W * scale
-  const h = AI_IMAGE_HOLDER_DEFAULT_H * scale
+  const settings = getActiveCanvasSettings()
+  const w = settings.aiImageHolderWidth * scale
+  const h = settings.aiImageHolderHeight * scale
   const center = editor.getViewportPageBounds().center
   const id = createShapeId()
 
@@ -370,7 +548,7 @@ function getDefaultAnnotationArrowBend(dx, dy, scale) {
 
 function getAnnotationColor(editor) {
   const color = editor.getStyleForNextShape(DefaultColorStyle)
-  return color === DefaultColorStyle.defaultValue ? ANNOTATION_DEFAULT_COLOR : color
+  return color === DefaultColorStyle.defaultValue ? getActiveCanvasSettings().annotationColor : color
 }
 
 class CowartAnnotationTool extends StateNode {
@@ -531,7 +709,7 @@ class CowartFrameShapeUtil extends FrameShapeUtil {
   }
 }
 
-const cowartShapeUtils = [CowartFrameShapeUtil]
+const cowartShapeUtils = [CowartFrameShapeUtil, CowartImageShapeUtil]
 
 const cowartUiOverrides = {
   translations: {
@@ -561,12 +739,13 @@ const cowartUiOverrides = {
         },
         onDragStart(source, info) {
           const scale = editor.getResizeScaleFactor()
+          const settings = getActiveCanvasSettings()
           onDragFromToolbarToCreateShape(editor, info, {
             createShape: (id) =>
               createAiImageHolderShape(editor, id, {
                 props: {
-                  w: AI_IMAGE_HOLDER_DEFAULT_W * scale,
-                  h: AI_IMAGE_HOLDER_DEFAULT_H * scale
+                  w: settings.aiImageHolderWidth * scale,
+                  h: settings.aiImageHolderHeight * scale
                 }
               }),
             onDragEnd: (id) => editor.select(id)
@@ -911,6 +1090,7 @@ function getCowartSelection(editor) {
       x: shape?.x ?? null,
       y: shape?.y ?? null,
       rotation: shape?.rotation ?? null,
+      opacity: shape?.opacity ?? null,
       meta: shape?.meta ?? null,
       isAiImageHolder: shape?.meta?.cowartAiImageHolder === true,
       props: shape?.props ?? null,
@@ -987,37 +1167,51 @@ function writeCowartSelectionState(selectionSnapshot) {
 export default function App() {
   const [snapshot, setSnapshot] = useState()
   const [viewState, setViewState] = useState()
+  const [settings, setSettings] = useState()
+  const [settingsSaveState, setSettingsSaveState] = useState('saved')
+  const [selectedShapes, setSelectedShapes] = useState([])
   const [loadError, setLoadError] = useState(null)
   const [skippedRecords, setSkippedRecords] = useState([])
+  const [editorInstance, setEditorInstance] = useState(null)
+  const didLoadSettingsRef = useRef(false)
 
   useEffect(() => {
     const controller = new AbortController()
 
     async function loadCanvas() {
       try {
-        const [canvasResponse, viewStateResponse] = await Promise.all([
+        const [canvasResponse, viewStateResponse, settingsResponse] = await Promise.all([
           fetch(CANVAS_ENDPOINT, { signal: controller.signal }),
-          fetch(VIEW_STATE_ENDPOINT, { signal: controller.signal })
+          fetch(VIEW_STATE_ENDPOINT, { signal: controller.signal }),
+          fetch(SETTINGS_ENDPOINT, { signal: controller.signal })
         ])
         if (!canvasResponse.ok) {
-          throw new Error(`Failed to load canvas: ${canvasResponse.status} - ${canvasResponse.statusText}`)
+          throw new Error(`Failed to load canvas: ${canvasResponse.status}`)
         }
         if (!viewStateResponse.ok) {
-          throw new Error(`Failed to load canvas view state: ${viewStateResponse.status} - ${viewStateResponse.statusText}`)
+          throw new Error(`Failed to load canvas view state: ${viewStateResponse.status}`)
         }
-        const [canvasData, viewStateData] = await Promise.all([
+        if (!settingsResponse.ok) {
+          throw new Error(`Failed to load canvas settings: ${settingsResponse.status}`)
+        }
+        const [canvasData, viewStateData, settingsData] = await Promise.all([
           canvasResponse.json(),
-          viewStateResponse.json()
+          viewStateResponse.json(),
+          settingsResponse.json()
         ])
         const sanitized = sanitizeCanvasSnapshotForTldraw(canvasData.snapshot)
         setSnapshot(sanitized.snapshot)
         setSkippedRecords(sanitized.skippedRecords)
         setViewState(viewStateData.viewState ?? null)
+        setSettings(normalizeCanvasSettings(settingsData.settings))
+        didLoadSettingsRef.current = true
       } catch (error) {
         if (error.name === 'AbortError') return
         setLoadError(error)
         setSnapshot(null)
         setViewState(null)
+        setSettings(DEFAULT_CANVAS_SETTINGS)
+        didLoadSettingsRef.current = true
       }
     }
 
@@ -1026,10 +1220,60 @@ export default function App() {
     return () => controller.abort()
   }, [])
 
+  useEffect(() => {
+    window.__cowartSettings = settings
+  }, [settings])
+
+  useEffect(() => {
+    if (!settings) return
+    document.documentElement.style.setProperty('--cowart-canvas-background', settings.backgroundColor)
+  }, [settings])
+
+  useEffect(() => {
+    const editor = window.__cowartEditor
+    if (!settings || !editor) return
+    editor.updateInstanceState({ isGridMode: settings.showGrid })
+    editor.setStyleForNextShapes(DefaultColorStyle, settings.annotationColor)
+  }, [settings])
+
+  useEffect(() => {
+    if (!settings || !didLoadSettingsRef.current) return undefined
+
+    setSettingsSaveState('saving')
+    const controller = new AbortController()
+    const timer = window.setTimeout(async () => {
+      try {
+        const response = await fetch(SETTINGS_ENDPOINT, {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(settings),
+          signal: controller.signal
+        })
+        if (!response.ok) {
+          throw new Error(`Failed to save canvas settings: ${response.status}`)
+        }
+        setSettingsSaveState('saved')
+      } catch (error) {
+        if (error.name === 'AbortError') return
+        console.error(error)
+        setSettingsSaveState('error')
+      }
+    }, 350)
+
+    return () => {
+      controller.abort()
+      window.clearTimeout(timer)
+    }
+  }, [settings])
+
   const handleMount = useCallback((editor) => {
     window.__cowartEditor = editor
     window.__cowartSelection = () => getCowartSelection(editor)
     window.__cowartViewState = () => getCowartViewState(editor)
+    setEditorInstance(editor)
+    setSelectedShapes(getCowartSelection(editor))
+    editor.updateInstanceState({ isGridMode: settings.showGrid })
+    editor.setStyleForNextShapes(DefaultColorStyle, settings.annotationColor)
     let lastSyncedSelectionState = ''
     let isSelectionStateSaving = false
     let hasPendingSelectionState = false
@@ -1043,6 +1287,7 @@ export default function App() {
 
     async function syncSelectionState() {
       const selectionSnapshot = getCowartSelectionSnapshot(editor)
+      setSelectedShapes(selectionSnapshot.selectedShapes)
       writeCowartSelectionState(selectionSnapshot)
 
       const selectionState = JSON.stringify(selectionSnapshot)
@@ -1137,7 +1382,7 @@ export default function App() {
 
       isSaving = true
       try {
-        const body = JSON.stringify(editor.store.getStoreSnapshot())
+        const body = JSON.stringify(sanitizeCanvasSnapshot(editor.store.getStoreSnapshot()))
         const response = await fetch(CANVAS_ENDPOINT, {
           method: 'PUT',
           headers: { 'content-type': 'application/json' },
@@ -1292,6 +1537,8 @@ export default function App() {
       window.clearInterval(viewStateTimer)
       remoteLoadController?.abort()
       canvasEvents?.close()
+      setEditorInstance((current) => (current === editor ? null : current))
+      setSelectedShapes((current) => (window.__cowartEditor === editor ? [] : current))
       if (window.__cowartEditor === editor) {
         delete window.__cowartEditor
         delete window.__cowartSelection
@@ -1304,9 +1551,9 @@ export default function App() {
       syncViewState()
       saveCanvas()
     }
-  }, [viewState])
+  }, [settings, viewState])
 
-  if (snapshot === undefined || viewState === undefined) {
+  if (snapshot === undefined || viewState === undefined || settings === undefined) {
     return (
       <main className="cowart-status" aria-live="polite">
         Loading canvas...
@@ -1325,6 +1572,17 @@ export default function App() {
   return (
     <main className="cowart-canvas" aria-label="Cowart infinite canvas">
       <SkippedRecordsNotice records={skippedRecords} />
+      <CowartInspector
+        editor={editorInstance}
+        selectedShapes={selectedShapes}
+        settings={settings}
+        saveState={settingsSaveState}
+        annotationColorOptions={ANNOTATION_COLOR_OPTIONS}
+        onChangeSettings={(patch) =>
+          setSettings((current) => normalizeCanvasSettings({ ...current, ...patch }))
+        }
+        onResetSettings={() => setSettings(DEFAULT_CANVAS_SETTINGS)}
+      />
       <Tldraw
         snapshot={snapshot ?? undefined}
         inferDarkMode

--- a/src/components/CowartImageShapeUtil.jsx
+++ b/src/components/CowartImageShapeUtil.jsx
@@ -1,0 +1,507 @@
+import { memo } from 'react'
+import {
+  HTMLContainer,
+  ImageShapeUtil,
+  MediaHelpers,
+  getUncroppedSize,
+  useEditor,
+  useImageOrVideoAsset,
+  useValue
+} from 'tldraw'
+
+const imageSvgExportCache = new WeakMap()
+const IMAGE_BORDER_SWATCHES = {
+  black: '#1f2430',
+  grey: '#697386',
+  'light-violet': '#b8a3ff',
+  violet: '#7c3aed',
+  blue: '#3e63dd',
+  'light-blue': '#8ec5ff',
+  yellow: '#f5d90a',
+  orange: '#f76b15',
+  green: '#30a46c',
+  'light-green': '#8fd19e',
+  'light-red': '#f39aa0',
+  red: '#e5484d',
+  white: '#ffffff'
+}
+
+function clampImageCornerRadius(shape, value) {
+  const width = Number(shape?.props?.w) || 0
+  const height = Number(shape?.props?.h) || 0
+  const maxRadius = Math.max(0, Math.floor(Math.min(width, height) / 2))
+  const radius = Number(value)
+  if (!Number.isFinite(radius)) return 0
+  return Math.min(Math.max(Math.round(radius), 0), maxRadius)
+}
+
+function getImageCornerRadius(shape) {
+  return clampImageCornerRadius(shape, shape?.meta?.cowartImageCornerRadius ?? 0)
+}
+
+function getImageBorderRadius(shape) {
+  if (shape.props.crop?.isCircle) return '50%'
+  const radius = getImageCornerRadius(shape)
+  return radius > 0 ? `${radius}px` : undefined
+}
+
+function getImageBorderWidth(shape) {
+  const width = Number(shape?.meta?.cowartImageBorderWidth ?? 0)
+  if (!Number.isFinite(width)) return 0
+  return Math.min(Math.max(Math.round(width), 0), 24)
+}
+
+function getImageBorderColor(shape) {
+  const key = shape?.meta?.cowartImageBorderColor
+  if (typeof key === 'string' && IMAGE_BORDER_SWATCHES[key]) {
+    return IMAGE_BORDER_SWATCHES[key]
+  }
+  return IMAGE_BORDER_SWATCHES.black
+}
+
+function getImageShadow(shape) {
+  const strength = Number(shape?.meta?.cowartImageShadow ?? 0)
+  if (!Number.isFinite(strength)) return 0
+  return Math.min(Math.max(Math.round(strength), 0), 100)
+}
+
+function getImageBlur(shape) {
+  const blur = Number(shape?.meta?.cowartImageBlur ?? 0)
+  if (!Number.isFinite(blur)) return 0
+  return Math.min(Math.max(Math.round(blur), 0), 40)
+}
+
+function getImageShadowColor(shape) {
+  const key = shape?.meta?.cowartImageShadowColor
+  if (typeof key === 'string' && IMAGE_BORDER_SWATCHES[key]) {
+    return IMAGE_BORDER_SWATCHES[key]
+  }
+  return IMAGE_BORDER_SWATCHES.black
+}
+
+function hexToRgb(color) {
+  const normalized = typeof color === 'string' ? color.replace('#', '') : ''
+  if (!/^[0-9a-fA-F]{6}$/.test(normalized)) {
+    return { r: 15, g: 23, b: 42 }
+  }
+
+  return {
+    r: Number.parseInt(normalized.slice(0, 2), 16),
+    g: Number.parseInt(normalized.slice(2, 4), 16),
+    b: Number.parseInt(normalized.slice(4, 6), 16)
+  }
+}
+
+function getImageBoxShadow(shape) {
+  const shadow = getImageShadow(shape)
+  if (shadow <= 0) return undefined
+  const blur = 10 + shadow * 0.36
+  const offsetY = 4 + shadow * 0.12
+  const alpha = Math.min(0.28, 0.06 + shadow * 0.0022)
+  const color = hexToRgb(getImageShadowColor(shape))
+  return `0 ${offsetY}px ${blur}px rgba(${color.r}, ${color.g}, ${color.b}, ${alpha})`
+}
+
+function getImageFrameStyle(shape) {
+  const borderWidth = getImageBorderWidth(shape)
+  const borderColor = getImageBorderColor(shape)
+  const borderRadius = getImageBorderRadius(shape)
+  return {
+    overflow: 'hidden',
+    width: shape.props.w,
+    height: shape.props.h,
+    borderRadius,
+    border: borderWidth > 0 ? `${borderWidth}px solid ${borderColor}` : undefined,
+    boxShadow: getImageBoxShadow(shape),
+    boxSizing: 'border-box'
+  }
+}
+
+function getImageElementStyle(shape) {
+  const blur = getImageBlur(shape)
+  const baseStyle = getFlipStyle(shape)
+  const filter = blur > 0 ? `blur(${blur}px)` : undefined
+
+  if (!baseStyle && !filter) return undefined
+
+  return {
+    ...(baseStyle ?? {}),
+    filter
+  }
+}
+
+function getCroppedContainerStyle(shape) {
+  const crop = shape.props.crop
+  const topLeft = crop?.topLeft
+  if (!topLeft) {
+    return {
+      width: shape.props.w,
+      height: shape.props.h
+    }
+  }
+
+  const { w, h } = getUncroppedSize(shape.props, crop)
+  const offsetX = -topLeft.x * w
+  const offsetY = -topLeft.y * h
+
+  return {
+    transform: `translate(${offsetX}px, ${offsetY}px)`,
+    width: w,
+    height: h
+  }
+}
+
+function modulate(value, [fromMin, fromMax], [toMin, toMax]) {
+  if (fromMax === fromMin) return toMin
+  const progress = (value - fromMin) / (fromMax - fromMin)
+  return toMin + progress * (toMax - toMin)
+}
+
+function getFlipStyle(shape, size) {
+  const { flipX, flipY, crop } = shape.props
+  if (!flipX && !flipY) return undefined
+
+  let cropOffsetX
+  let cropOffsetY
+  if (crop) {
+    const { w, h } = getUncroppedSize(shape.props, crop)
+    const cropWidth = crop.bottomRight.x - crop.topLeft.x
+    const cropHeight = crop.bottomRight.y - crop.topLeft.y
+
+    cropOffsetX = modulate(crop.topLeft.x, [0, 1 - cropWidth], [0, w - shape.props.w])
+    cropOffsetY = modulate(crop.topLeft.y, [0, 1 - cropHeight], [0, h - shape.props.h])
+  }
+
+  const scale = `scale(${flipX ? -1 : 1}, ${flipY ? -1 : 1})`
+  const translate = size
+    ? `translate(${(flipX ? size.width : 0) - (cropOffsetX ? cropOffsetX : 0)}px, ${(flipY ? size.height : 0) - (cropOffsetY ? cropOffsetY : 0)}px)`
+    : ''
+
+  return {
+    transform: `${translate} ${scale}`.trim(),
+    transformOrigin: size ? '0 0' : 'center center'
+  }
+}
+
+function assetIsAnimated(asset) {
+  if (!asset) return false
+
+  return (
+    ('mimeType' in asset.props && MediaHelpers.isAnimatedImageType(asset.props.mimeType)) ||
+    ('isAnimated' in asset.props && asset.props.isAnimated)
+  )
+}
+
+function blobToDataUrl(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : '')
+    reader.onerror = () => reject(reader.error)
+    reader.readAsDataURL(blob)
+  })
+}
+
+async function getDataUriFromUrl(url) {
+  const response = await fetch(url)
+  const blob = await response.blob()
+  return blobToDataUrl(blob)
+}
+
+function getFirstFrameOfAnimatedImage(url) {
+  let cancelled = false
+
+  const promise = new Promise((resolve) => {
+    const image = new window.Image()
+    image.onload = () => {
+      if (cancelled) return
+
+      const canvas = document.createElement('canvas')
+      canvas.width = image.width
+      canvas.height = image.height
+
+      const ctx = canvas.getContext('2d')
+      if (!ctx) {
+        resolve(url)
+        return
+      }
+
+      ctx.drawImage(image, 0, 0)
+      resolve(canvas.toDataURL())
+    }
+    image.crossOrigin = 'anonymous'
+    image.src = url
+  })
+
+  return {
+    promise,
+    cancel() {
+      cancelled = true
+    }
+  }
+}
+
+function getImageClipMarkup(shape, width, height) {
+  const crop = shape.props.crop
+  const radius = clampImageCornerRadius(shape, getImageCornerRadius(shape))
+  const borderWidth = Math.min(getImageBorderWidth(shape), width / 2, height / 2)
+  const insetX = borderWidth / 2
+  const insetY = borderWidth / 2
+  const insetWidth = Math.max(0, width - borderWidth)
+  const insetHeight = Math.max(0, height - borderWidth)
+
+  if (crop?.isCircle) {
+    return <ellipse cx={width / 2} cy={height / 2} rx={width / 2} ry={height / 2} />
+  }
+
+  if (radius > 0) {
+    const clippedRadius = Math.min(radius, insetWidth / 2, insetHeight / 2)
+    return (
+      <rect
+        x={insetX}
+        y={insetY}
+        width={insetWidth}
+        height={insetHeight}
+        rx={clippedRadius}
+        ry={clippedRadius}
+      />
+    )
+  }
+
+  return <rect x={insetX} y={insetY} width={insetWidth} height={insetHeight} />
+}
+
+function getSvgBorderMarkup(shape, width, height) {
+  const borderWidth = getImageBorderWidth(shape)
+  if (borderWidth <= 0) return null
+
+  const color = getImageBorderColor(shape)
+  const half = borderWidth / 2
+
+  if (shape.props.crop?.isCircle) {
+    return (
+      <ellipse
+        cx={width / 2}
+        cy={height / 2}
+        rx={Math.max(0, width / 2 - half)}
+        ry={Math.max(0, height / 2 - half)}
+        fill="none"
+        stroke={color}
+        strokeWidth={borderWidth}
+      />
+    )
+  }
+
+  const radius = Math.min(getImageCornerRadius(shape), (width - borderWidth) / 2, (height - borderWidth) / 2)
+  return (
+    <rect
+      x={half}
+      y={half}
+      width={Math.max(0, width - borderWidth)}
+      height={Math.max(0, height - borderWidth)}
+      rx={Math.max(0, radius)}
+      ry={Math.max(0, radius)}
+      fill="none"
+      stroke={color}
+      strokeWidth={borderWidth}
+    />
+  )
+}
+
+function SvgImage({ shape, src }) {
+  const crop = shape.props.crop
+  const containerStyle = getCroppedContainerStyle(shape)
+  const hasRoundedCorners = getImageCornerRadius(shape) > 0
+  const clipId = `cowart-image-clip-${String(shape.id).replace(/[^a-zA-Z0-9_-]/g, '-')}`
+
+  if (containerStyle.transform && crop) {
+    const { transform: cropTransform, width, height } = containerStyle
+    const croppedWidth = (crop.bottomRight.x - crop.topLeft.x) * width
+    const croppedHeight = (crop.bottomRight.y - crop.topLeft.y) * height
+    const flipStyle = getFlipStyle(shape, { width, height })
+
+    return (
+      <>
+        <defs>
+          <clipPath id={clipId}>{getImageClipMarkup(shape, croppedWidth, croppedHeight)}</clipPath>
+        </defs>
+        <g clipPath={`url(#${clipId})`}>
+          <image
+            href={src}
+            width={width}
+            height={height}
+            aria-label={shape.props.altText}
+            style={flipStyle ? { ...flipStyle } : { transform: cropTransform }}
+          />
+        </g>
+        {getSvgBorderMarkup(shape, croppedWidth, croppedHeight)}
+      </>
+    )
+  }
+
+  if (crop?.isCircle || hasRoundedCorners) {
+    return (
+      <>
+        <defs>
+          <clipPath id={clipId}>{getImageClipMarkup(shape, shape.props.w, shape.props.h)}</clipPath>
+        </defs>
+        <g clipPath={`url(#${clipId})`}>
+          <image
+            href={src}
+            width={shape.props.w}
+            height={shape.props.h}
+            aria-label={shape.props.altText}
+            style={getFlipStyle(shape, { width: shape.props.w, height: shape.props.h })}
+          />
+        </g>
+        {getSvgBorderMarkup(shape, shape.props.w, shape.props.h)}
+      </>
+    )
+  }
+
+  return (
+    <>
+      <image
+        href={src}
+        width={shape.props.w}
+        height={shape.props.h}
+        aria-label={shape.props.altText}
+        style={getFlipStyle(shape, { width: shape.props.w, height: shape.props.h })}
+      />
+      {getSvgBorderMarkup(shape, shape.props.w, shape.props.h)}
+    </>
+  )
+}
+
+const CowartImageShape = memo(function CowartImageShape({ shape }) {
+  const editor = useEditor()
+  const { w } = getUncroppedSize(shape.props, shape.props.crop)
+  const { asset, url } = useImageOrVideoAsset({
+    shapeId: shape.id,
+    assetId: shape.props.assetId,
+    width: w
+  })
+
+  const showCropPreview = useValue(
+    'show crop preview',
+    () =>
+      shape.id === editor.getOnlySelectedShapeId() &&
+      editor.getCroppingShapeId() === shape.id &&
+      editor.isIn('select.crop'),
+    [editor, shape.id]
+  )
+
+  const frameStyle = getImageFrameStyle(shape)
+  const containerStyle = getCroppedContainerStyle(shape)
+  const imageStyle = getImageElementStyle(shape)
+
+  if (!url && !asset?.props?.src) {
+    return (
+      <HTMLContainer
+        id={shape.id}
+        style={{
+          ...frameStyle,
+          color: 'var(--tl-color-text-3)',
+          backgroundColor: 'var(--tl-color-low)',
+          border: frameStyle.border ?? '1px solid var(--tl-color-low-border)'
+        }}
+      >
+        <div
+          className="tl-image-container"
+          style={{
+            ...containerStyle,
+            display: 'grid',
+            placeItems: 'center',
+            color: 'inherit'
+          }}
+        >
+          资源不可用
+        </div>
+      </HTMLContainer>
+    )
+  }
+
+  const src = url ?? asset?.props?.src ?? ''
+
+  return (
+    <>
+      {showCropPreview && src ? (
+        <div style={frameStyle}>
+          <div className="tl-image-container" style={containerStyle}>
+            <img
+              className="tl-image"
+              style={{ ...imageStyle, opacity: 0.1 }}
+              src={src}
+              referrerPolicy="strict-origin-when-cross-origin"
+              draggable={false}
+              alt=""
+            />
+          </div>
+        </div>
+      ) : null}
+      <HTMLContainer
+        id={shape.id}
+        style={frameStyle}
+      >
+        <div className="tl-image-container" style={containerStyle}>
+          <img
+            className="tl-image"
+            style={imageStyle}
+            src={src}
+            referrerPolicy="strict-origin-when-cross-origin"
+            draggable={false}
+            alt={shape.props.altText}
+          />
+        </div>
+      </HTMLContainer>
+    </>
+  )
+})
+
+export class CowartImageShapeUtil extends ImageShapeUtil {
+  static type = 'image'
+
+  component(shape) {
+    return <CowartImageShape shape={shape} />
+  }
+
+  async toSvg(shape, ctx) {
+    const props = shape.props
+    if (!props.assetId) return null
+
+    const asset = this.editor.getAsset(props.assetId)
+    if (!asset) return null
+
+    const { w } = getUncroppedSize(shape.props, props.crop)
+    let srcPromise = imageSvgExportCache.get(asset)
+
+    if (!srcPromise) {
+      srcPromise = (async () => {
+        let src = await ctx.resolveAssetUrl(asset.id, w)
+        if (!src) return null
+
+        if (
+          src.startsWith('blob:') ||
+          src.startsWith('http') ||
+          src.startsWith('/') ||
+          src.startsWith('./')
+        ) {
+          src = await getDataUriFromUrl(src)
+        }
+
+        if (assetIsAnimated(asset)) {
+          const { promise } = getFirstFrameOfAnimatedImage(src)
+          src = await promise
+        }
+
+        return src
+      })()
+
+      imageSvgExportCache.set(asset, srcPromise)
+    }
+
+    const src = await srcPromise
+    if (!src) return null
+
+    return <SvgImage shape={shape} src={src} />
+  }
+}

--- a/src/components/CowartInspector.jsx
+++ b/src/components/CowartInspector.jsx
@@ -1,4 +1,10 @@
 import { useEffect, useState } from 'react'
+import {
+  COWART_TEXT_FONT_OPTIONS,
+  getCowartDefaultFontSize,
+  getCowartFontKey,
+  getCowartNearestSizeStyle
+} from './cowartTextStyles.js'
 
 const SHAPE_COLOR_OPTIONS = [
   { value: 'black', label: '黑色', swatch: '#1f2430' },
@@ -40,13 +46,6 @@ const SIZE_OPTIONS = [
   { value: 'xl', label: '特粗' }
 ]
 
-const FONT_OPTIONS = [
-  { value: 'draw', label: '手绘' },
-  { value: 'sans', label: '无衬线' },
-  { value: 'serif', label: '衬线' },
-  { value: 'mono', label: '等宽' }
-]
-
 const ALIGN_OPTIONS = [
   { value: 'start', label: '左对齐' },
   { value: 'middle', label: '居中' },
@@ -77,31 +76,9 @@ const VERTICAL_ALIGN_BUTTONS = [
   { value: 'end', label: '下' }
 ]
 
-const EXPORT_PRESET_OPTIONS = [
-  {
-    value: 'selection-png',
-    label: '选区 PNG',
-    format: 'png',
-    scale: 2,
-    background: false,
-    scope: 'selection'
-  },
-  {
-    value: 'selection-svg',
-    label: '选区 SVG',
-    format: 'svg',
-    scale: 1,
-    background: false,
-    scope: 'selection'
-  },
-  {
-    value: 'page-png',
-    label: '整页 PNG',
-    format: 'png',
-    scale: 2,
-    background: true,
-    scope: 'page'
-  }
+const EXPORT_SCOPE_OPTIONS = [
+  { value: 'selection', label: '选区' },
+  { value: 'page', label: '整页' }
 ]
 
 const EXPORT_FORMAT_OPTIONS = [
@@ -244,6 +221,7 @@ function getSelectionShapeIds(editor) {
 
 function getExportTargetShapeIds(editor, scope) {
   if (scope === 'page') return getCurrentPageShapeIds(editor)
+  if (scope === 'selection') return getSelectionShapeIds(editor)
 
   const selectedShapeIds = getSelectionShapeIds(editor)
   if (selectedShapeIds.length > 0) return selectedShapeIds
@@ -252,6 +230,10 @@ function getExportTargetShapeIds(editor, scope) {
 
 function getExportTargetLabel(editor, scope = 'auto') {
   const selectedShapeIds = getSelectionShapeIds(editor)
+  if (scope === 'selection') {
+    return selectedShapeIds.length === 1 ? '当前选中对象' : `当前选中 ${selectedShapeIds.length} 个对象`
+  }
+
   if (scope !== 'page' && selectedShapeIds.length > 0) {
     return selectedShapeIds.length === 1 ? '当前选中对象' : `当前选中 ${selectedShapeIds.length} 个对象`
   }
@@ -342,6 +324,10 @@ function shouldShowTextStyleSection(shape) {
   return shape?.type === 'text' || shape?.type === 'note'
 }
 
+function shouldHideStrokeSection(shape) {
+  return shape?.type === 'text' || shape?.type === 'note'
+}
+
 function getImageCornerRadiusValue(shape) {
   if (!supportsImageCornerRadius(shape)) return 0
   const width = Number(shape.props?.w) || 0
@@ -381,6 +367,61 @@ function getImageBlurValue(shape) {
 function getImageShadowColorValue(shape) {
   if (!supportsImageCornerRadius(shape)) return 'black'
   return resolveColorOptionValue(shape?.meta?.cowartImageShadowColor, SHAPE_COLOR_OPTIONS) ?? 'black'
+}
+
+function supportsTextColor(shape) {
+  if (shape?.type === 'text') return typeof shape?.props?.color === 'string'
+  return typeof shape?.props?.labelColor === 'string'
+}
+
+function getTextColorValue(shape) {
+  if (!supportsTextColor(shape)) return 'black'
+  if (shape?.type === 'text') {
+    return resolveColorOptionValue(shape?.props?.color, SHAPE_COLOR_OPTIONS) ?? 'black'
+  }
+  return resolveColorOptionValue(shape?.props?.labelColor, SHAPE_COLOR_OPTIONS) ?? 'black'
+}
+
+function getTextFontSizeValue(shape) {
+  const raw = Number(shape?.meta?.cowartTextFontSize)
+  if (Number.isFinite(raw) && raw > 0) {
+    return Math.min(Math.max(Math.round(raw), 8), 240)
+  }
+  return getCowartDefaultFontSize(shape)
+}
+
+function getTextFontFamilyValue(shape) {
+  return getCowartFontKey(shape)
+}
+
+function getTextWeightValue(shape) {
+  const weight = Number(shape?.meta?.cowartTextFontWeight ?? 400)
+  if (!Number.isFinite(weight)) return 400
+  return Math.min(Math.max(Math.round(weight), 100), 900)
+}
+
+function getTextLineHeightValue(shape) {
+  const value = Number(shape?.meta?.cowartTextLineHeight ?? 1.35)
+  if (!Number.isFinite(value)) return 1.35
+  return Math.min(Math.max(Math.round(value * 100) / 100, 0.8), 3)
+}
+
+function getTextLetterSpacingValue(shape) {
+  const value = Number(shape?.meta?.cowartTextLetterSpacing ?? 0)
+  if (!Number.isFinite(value)) return 0
+  return Math.min(Math.max(Math.round(value * 10) / 10, -8), 40)
+}
+
+function getTextUnderlineValue(shape) {
+  return shape?.meta?.cowartTextUnderline === true
+}
+
+function getTextStrikeValue(shape) {
+  return shape?.meta?.cowartTextStrike === true
+}
+
+function getTextItalicValue(shape) {
+  return shape?.meta?.cowartTextItalic === true
 }
 
 function ColorControl({ label, value, onChange, options = SHAPE_COLOR_OPTIONS }) {
@@ -812,12 +853,13 @@ function StyleSection({
   const canEditStrokeDash = supportsStrokeDash(shape)
   const canEditStrokeSize = supportsStrokeSize(shape)
   const canEditImageCornerRadius = supportsImageCornerRadius(shape)
+  const hideStrokeSection = shouldHideStrokeSection(shape)
   const canRenderOpacityRow = canEditOpacity && !canEditFill
   const canRenderSection =
     canEditFill ||
-    canEditStrokeDash ||
-    canEditStrokeSize ||
-    canEditStrokeColor ||
+    (!hideStrokeSection && canEditStrokeDash) ||
+    (!hideStrokeSection && canEditStrokeSize) ||
+    (!hideStrokeSection && canEditStrokeColor) ||
     canRenderOpacityRow ||
     canEditImageCornerRadius
 
@@ -1004,7 +1046,7 @@ function StyleSection({
         </div>
       )}
 
-      {(canEditStrokeDash || canEditStrokeSize || canEditStrokeColor) && (
+      {!hideStrokeSection && (canEditStrokeDash || canEditStrokeSize || canEditStrokeColor) && (
         <div className="cowart-property-row cowart-property-row-compact">
           <span className="cowart-property-label">描边</span>
 
@@ -1047,9 +1089,88 @@ function TextStyleSection({ shape, onChangeStyle }) {
   const canEditHorizontalAlign = supportsHorizontalAlign(shape)
   const canEditTextAlign = supportsTextAlign(shape)
   const canEditVerticalAlign = supportsVerticalAlign(shape)
-  const canEditLabelColor = supportsLabelColor(shape)
+  const canEditTextColor = supportsTextColor(shape)
+  const textColorValue = getTextColorValue(shape)
+  const textFontSizeValue = getTextFontSizeValue(shape)
+  const textFontFamilyValue = getTextFontFamilyValue(shape)
+  const textWeightValue = getTextWeightValue(shape)
+  const textLineHeightValue = getTextLineHeightValue(shape)
+  const textLetterSpacingValue = getTextLetterSpacingValue(shape)
+  const textUnderlineValue = getTextUnderlineValue(shape)
+  const textStrikeValue = getTextStrikeValue(shape)
+  const textItalicValue = getTextItalicValue(shape)
 
   if (!shouldRenderTextSection) return null
+
+  function updateTextMeta(partialMeta) {
+    window.__cowartEditor?.updateShapes?.([
+      {
+        id: shape.id,
+        type: shape.type,
+        meta: {
+          ...(shape.meta ?? {}),
+          ...partialMeta
+        }
+      }
+    ])
+  }
+
+  function handleChangeTextFontSize(nextFontSize) {
+    const roundedFontSize = clampNumber(nextFontSize, 8, 240, textFontSizeValue)
+    const nextSizeStyle = getCowartNearestSizeStyle(shape.type, roundedFontSize)
+
+    onChangeStyle({
+      size: nextSizeStyle,
+      ...(shape.type === 'note' ? { fontSizeAdjustment: 1 } : {})
+    })
+
+    updateTextMeta({ cowartTextFontSize: roundedFontSize })
+  }
+
+  function handleChangeTextFontFamily(nextFontFamily) {
+    const option = COWART_TEXT_FONT_OPTIONS.find((item) => item.value === nextFontFamily)
+    if (!option) return
+
+    onChangeStyle({
+      font: option.baseFont,
+      ...(shape.type === 'note' ? { fontSizeAdjustment: 1 } : {})
+    })
+
+    updateTextMeta({ cowartTextFontFamily: option.value })
+  }
+
+  function handleChangeTextColor(nextColor) {
+    if (shape.type === 'text') {
+      onChangeStyle({ color: nextColor })
+      return
+    }
+
+    onChangeStyle({ labelColor: nextColor })
+  }
+
+  function handleChangeTextAlign(nextAlign) {
+    if (shape.type === 'text' && shape.props.autoSize) {
+      const editor = window.__cowartEditor
+      if (editor) {
+        const bounds = editor.getShapeGeometry(shape).bounds
+        const nextWidth = Math.max(160, Math.ceil(bounds.width + 40))
+        editor.updateShapes([
+          {
+            id: shape.id,
+            type: shape.type,
+            props: {
+              textAlign: nextAlign,
+              autoSize: false,
+              w: nextWidth
+            }
+          }
+        ])
+        return
+      }
+    }
+
+    onChangeStyle({ textAlign: nextAlign })
+  }
 
   return (
     <section className="cowart-property-group cowart-property-group-text">
@@ -1059,18 +1180,129 @@ function TextStyleSection({ shape, onChangeStyle }) {
 
       {(canEditFont || canEditHorizontalAlign || canEditTextAlign || canEditVerticalAlign) && (
         <div className="cowart-text-control-stack">
-          {canEditFont && (
+          {canEditFont ? (
+            <div className="cowart-inline-control-row">
+              <label className="cowart-compact-select cowart-compact-select-surface">
+                <span>字体</span>
+                <select value={textFontFamilyValue} onChange={(event) => handleChangeTextFontFamily(event.target.value)}>
+                  {COWART_TEXT_FONT_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="cowart-compact-select cowart-compact-select-surface">
+                <span>字号</span>
+                <div className="cowart-input-with-suffix">
+                  <input
+                    type="number"
+                    min="8"
+                    max="240"
+                    step="1"
+                    value={textFontSizeValue}
+                    onChange={(event) => handleChangeTextFontSize(event.target.value)}
+                  />
+                  <em>px</em>
+                </div>
+              </label>
+            </div>
+          ) : null}
+
+          <div className="cowart-inline-control-row">
             <label className="cowart-compact-select cowart-compact-select-surface">
-              <span>字体</span>
-              <select value={shape.props.font} onChange={(event) => onChangeStyle({ font: event.target.value })}>
-                {FONT_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
+              <span>字重</span>
+              <div className="cowart-input-with-suffix">
+                <input
+                  type="number"
+                  min="100"
+                  max="900"
+                  step="100"
+                  value={textWeightValue}
+                  onChange={(event) =>
+                    updateTextMeta({
+                      cowartTextFontWeight: clampNumber(event.target.value, 100, 900, textWeightValue)
+                    })
+                  }
+                />
+                <em>w</em>
+              </div>
+            </label>
+
+            <label className="cowart-compact-select cowart-compact-select-surface">
+              <span>行高</span>
+              <div className="cowart-input-with-suffix">
+                <input
+                  type="number"
+                  min="0.8"
+                  max="3"
+                  step="0.05"
+                  value={textLineHeightValue}
+                  onChange={(event) =>
+                    updateTextMeta({
+                      cowartTextLineHeight: Math.min(
+                        Math.max(Number(event.target.value) || textLineHeightValue, 0.8),
+                        3
+                      )
+                    })
+                  }
+                />
+                <em>x</em>
+              </div>
+            </label>
+          </div>
+
+          <div className="cowart-inline-control-row">
+            <label className="cowart-compact-select cowart-compact-select-surface">
+              <span>字间距</span>
+              <div className="cowart-input-with-suffix">
+                <input
+                  type="number"
+                  min="-8"
+                  max="40"
+                  step="0.5"
+                  value={textLetterSpacingValue}
+                  onChange={(event) =>
+                    updateTextMeta({
+                      cowartTextLetterSpacing: Math.min(
+                        Math.max(Number(event.target.value) || textLetterSpacingValue, -8),
+                        40
+                      )
+                    })
+                  }
+                />
+                <em>px</em>
+              </div>
+            </label>
+
+            <label className="cowart-compact-select cowart-compact-select-surface">
+              <span>样式</span>
+              <select
+                value={
+                  textUnderlineValue
+                    ? 'underline'
+                    : textStrikeValue
+                      ? 'strike'
+                      : textItalicValue
+                        ? 'italic'
+                        : 'normal'
+                }
+                onChange={(event) =>
+                  updateTextMeta({
+                    cowartTextItalic: event.target.value === 'italic',
+                    cowartTextUnderline: event.target.value === 'underline',
+                    cowartTextStrike: event.target.value === 'strike'
+                  })
+                }
+              >
+                <option value="normal">常规</option>
+                <option value="italic">斜体</option>
+                <option value="underline">下划线</option>
+                <option value="strike">删除线</option>
               </select>
             </label>
-          )}
+          </div>
 
           {(canEditHorizontalAlign || canEditTextAlign || canEditVerticalAlign) && (
             <div className="cowart-text-segment-grid">
@@ -1088,7 +1320,7 @@ function TextStyleSection({ shape, onChangeStyle }) {
                   label="文本"
                   value={shape.props.textAlign}
                   options={TEXT_ALIGN_BUTTONS}
-                  onChange={(textAlign) => onChangeStyle({ textAlign })}
+                  onChange={handleChangeTextAlign}
                 />
               )}
 
@@ -1105,11 +1337,11 @@ function TextStyleSection({ shape, onChangeStyle }) {
         </div>
       )}
 
-      {canEditLabelColor && (
+      {canEditTextColor && (
         <ColorControl
           label="文字颜色"
-          value={shape.props.labelColor}
-          onChange={(labelColor) => onChangeStyle({ labelColor })}
+          value={textColorValue}
+          onChange={handleChangeTextColor}
         />
       )}
 
@@ -1117,7 +1349,7 @@ function TextStyleSection({ shape, onChangeStyle }) {
         !canEditHorizontalAlign &&
         !canEditTextAlign &&
         !canEditVerticalAlign &&
-        !canEditLabelColor && (
+        !canEditTextColor && (
           <p className="cowart-section-empty">这个对象暂时没有可在右侧栏编辑的文字样式字段。</p>
         )}
     </section>
@@ -1203,7 +1435,7 @@ function CanvasSettingsSection({
         </div>
 
         <ColorControl
-          label="批注颜色"
+          label="颜色"
           value={currentColor.value}
           options={annotationColorOptions}
           onChange={(annotationColor) => onChangeSettings({ annotationColor })}
@@ -1218,18 +1450,20 @@ function CanvasSettingsSection({
 }
 
 function ExportSection({ editor }) {
+  const [scope, setScope] = useState('selection')
   const [format, setFormat] = useState('png')
   const [scale, setScale] = useState(2)
   const [includeBackground, setIncludeBackground] = useState(true)
   const [isExporting, setIsExporting] = useState(false)
   const [exportMessage, setExportMessage] = useState('')
+  const hasSelection = editor ? getSelectionShapeIds(editor).length > 0 : false
 
   async function runExport({ format: nextFormat, scale: nextScale, background, scope = 'auto' }) {
     if (!editor) return
 
     const shapeIds = getExportTargetShapeIds(editor, scope)
     if (shapeIds.length === 0) {
-      setExportMessage('当前页面没有可导出的内容。')
+      setExportMessage(scope === 'selection' ? '请先选择要导出的对象。' : '当前页面没有可导出的内容。')
       return
     }
 
@@ -1262,30 +1496,39 @@ function ExportSection({ editor }) {
 
   return (
     <section className="cowart-inspector-section cowart-inspector-section-compact" aria-label="导出">
-      <div className="cowart-style-stack">
-        <div className="cowart-property-group-header">
-          <h4>导出</h4>
-        </div>
-        <div className="cowart-preset-grid">
-          {EXPORT_PRESET_OPTIONS.map((preset) => (
-            <button
-              key={preset.value}
-              className="cowart-preset-button"
-              type="button"
-              disabled={!editor || (preset.scope === 'selection' && getSelectionShapeIds(editor).length === 0) || isExporting}
-              onClick={() => runExport(preset)}
-            >
-              {preset.label}
-            </button>
-          ))}
-        </div>
+      <div className="cowart-property-group-header">
+        <h4>导出</h4>
+      </div>
+
+      <div className="cowart-setting-row cowart-setting-row-surface">
+        <span>当前目标</span>
+        <strong>
+          {editor
+            ? scope === 'selection'
+              ? hasSelection
+                ? getExportTargetLabel(editor, 'selection')
+                : '未选择对象'
+              : getExportTargetLabel(editor, 'page')
+            : '画布未就绪'}
+        </strong>
       </div>
 
       <p className="cowart-section-note">
-        {editor ? `导出目标：${getExportTargetLabel(editor)}` : '画布加载后可导出当前选中对象或当前页面。'}
+        {editor ? '按范围、格式和倍率设置后直接导出。' : '画布加载后可导出选区或当前页面。'}
       </p>
 
       <div className="cowart-inline-control-row">
+        <label className="cowart-setting-stack">
+          <span>范围</span>
+          <select value={scope} onChange={(event) => setScope(event.target.value)}>
+            {EXPORT_SCOPE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
         <label className="cowart-setting-stack">
           <span>格式</span>
           <select value={format} onChange={(event) => setFormat(event.target.value)}>
@@ -1323,14 +1566,15 @@ function ExportSection({ editor }) {
         type="button"
         onClick={() =>
           runExport({
+            scope,
             format,
             scale,
             background: includeBackground
           })
         }
-        disabled={!editor || isExporting}
+        disabled={!editor || isExporting || (scope === 'selection' && !hasSelection)}
       >
-        {isExporting ? '导出中...' : '自定义导出'}
+        {isExporting ? '导出中...' : '导出'}
       </button>
 
       {exportMessage ? <p className="cowart-section-note">{exportMessage}</p> : null}

--- a/src/components/CowartInspector.jsx
+++ b/src/components/CowartInspector.jsx
@@ -1,0 +1,1444 @@
+import { useEffect, useState } from 'react'
+
+const SHAPE_COLOR_OPTIONS = [
+  { value: 'black', label: '黑色', swatch: '#1f2430' },
+  { value: 'grey', label: '灰色', swatch: '#697386' },
+  { value: 'light-violet', label: '浅紫', swatch: '#b8a3ff' },
+  { value: 'violet', label: '紫色', swatch: '#7c3aed' },
+  { value: 'blue', label: '蓝色', swatch: '#3e63dd' },
+  { value: 'light-blue', label: '浅蓝', swatch: '#8ec5ff' },
+  { value: 'yellow', label: '黄色', swatch: '#f5d90a' },
+  { value: 'orange', label: '橙色', swatch: '#f76b15' },
+  { value: 'green', label: '绿色', swatch: '#30a46c' },
+  { value: 'light-green', label: '浅绿', swatch: '#8fd19e' },
+  { value: 'light-red', label: '浅红', swatch: '#f39aa0' },
+  { value: 'red', label: '红色', swatch: '#e5484d' },
+  { value: 'white', label: '白色', swatch: '#ffffff' }
+]
+
+const FILL_OPTIONS = [
+  { value: 'none', label: '无填充' },
+  { value: 'semi', label: '半透明' },
+  { value: 'solid', label: '纯色' },
+  { value: 'pattern', label: '纹理' },
+  { value: 'fill', label: '填满' },
+  { value: 'lined-fill', label: '线性填充' }
+]
+
+const DASH_OPTIONS = [
+  { value: 'draw', label: '手绘' },
+  { value: 'solid', label: '实线' },
+  { value: 'dashed', label: '虚线' },
+  { value: 'dotted', label: '点线' },
+  { value: 'none', label: '无描边' }
+]
+
+const SIZE_OPTIONS = [
+  { value: 's', label: '细' },
+  { value: 'm', label: '中' },
+  { value: 'l', label: '粗' },
+  { value: 'xl', label: '特粗' }
+]
+
+const FONT_OPTIONS = [
+  { value: 'draw', label: '手绘' },
+  { value: 'sans', label: '无衬线' },
+  { value: 'serif', label: '衬线' },
+  { value: 'mono', label: '等宽' }
+]
+
+const ALIGN_OPTIONS = [
+  { value: 'start', label: '左对齐' },
+  { value: 'middle', label: '居中' },
+  { value: 'end', label: '右对齐' }
+]
+
+const VERTICAL_ALIGN_OPTIONS = [
+  { value: 'start', label: '顶部' },
+  { value: 'middle', label: '居中' },
+  { value: 'end', label: '底部' }
+]
+
+const HORIZONTAL_ALIGN_BUTTONS = [
+  { value: 'start', label: '左' },
+  { value: 'middle', label: '中' },
+  { value: 'end', label: '右' }
+]
+
+const TEXT_ALIGN_BUTTONS = [
+  { value: 'start', label: '左' },
+  { value: 'middle', label: '中' },
+  { value: 'end', label: '右' }
+]
+
+const VERTICAL_ALIGN_BUTTONS = [
+  { value: 'start', label: '上' },
+  { value: 'middle', label: '中' },
+  { value: 'end', label: '下' }
+]
+
+const EXPORT_PRESET_OPTIONS = [
+  {
+    value: 'selection-png',
+    label: '选区 PNG',
+    format: 'png',
+    scale: 2,
+    background: false,
+    scope: 'selection'
+  },
+  {
+    value: 'selection-svg',
+    label: '选区 SVG',
+    format: 'svg',
+    scale: 1,
+    background: false,
+    scope: 'selection'
+  },
+  {
+    value: 'page-png',
+    label: '整页 PNG',
+    format: 'png',
+    scale: 2,
+    background: true,
+    scope: 'page'
+  }
+]
+
+const EXPORT_FORMAT_OPTIONS = [
+  { value: 'png', label: 'PNG' },
+  { value: 'svg', label: 'SVG' },
+  { value: 'jpeg', label: 'JPEG' },
+  { value: 'webp', label: 'WebP' }
+]
+
+const EXPORT_SCALE_OPTIONS = [
+  { value: 1, label: '1x' },
+  { value: 2, label: '2x' },
+  { value: 3, label: '3x' }
+]
+
+function normalizeHexColor(value) {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim().replace(/^#/, '')
+
+  if (/^[0-9a-fA-F]{3}$/.test(normalized)) {
+    return `#${normalized
+      .split('')
+      .map((char) => char + char)
+      .join('')
+      .toLowerCase()}`
+  }
+
+  if (/^[0-9a-fA-F]{6}$/.test(normalized)) {
+    return `#${normalized.toLowerCase()}`
+  }
+
+  return null
+}
+
+function hexToRgb(value) {
+  const normalized = normalizeHexColor(value)
+  if (!normalized) return null
+
+  return {
+    r: Number.parseInt(normalized.slice(1, 3), 16),
+    g: Number.parseInt(normalized.slice(3, 5), 16),
+    b: Number.parseInt(normalized.slice(5, 7), 16)
+  }
+}
+
+function resolveColorOptionValue(value, options = SHAPE_COLOR_OPTIONS) {
+  if (typeof value !== 'string' || value.length === 0) return null
+
+  const matchedOption = options.find((option) => option.value === value)
+  if (matchedOption) return matchedOption.value
+
+  const targetColor = hexToRgb(value)
+  if (!targetColor) return null
+
+  let closestOption = options[0] ?? null
+  let closestDistance = Number.POSITIVE_INFINITY
+
+  for (const option of options) {
+    const optionColor = hexToRgb(option.swatch)
+    if (!optionColor) continue
+
+    const distance =
+      (targetColor.r - optionColor.r) ** 2 +
+      (targetColor.g - optionColor.g) ** 2 +
+      (targetColor.b - optionColor.b) ** 2
+
+    if (distance < closestDistance) {
+      closestOption = option
+      closestDistance = distance
+    }
+  }
+
+  return closestOption?.value ?? null
+}
+
+function resolveColorSwatch(value, options = SHAPE_COLOR_OPTIONS) {
+  const resolvedValue = resolveColorOptionValue(value, options)
+  const matchedOption = options.find((option) => option.value === resolvedValue)
+  return matchedOption?.swatch ?? options[0]?.swatch ?? '#1f2430'
+}
+
+function getColorDisplayValue(value, options = SHAPE_COLOR_OPTIONS) {
+  if (typeof value !== 'string' || value.length === 0) return ''
+  return normalizeHexColor(value) ?? options.find((option) => option.value === value)?.swatch ?? value
+}
+
+function clampNumber(value, min, max, fallback) {
+  const number = Number(value)
+  if (!Number.isFinite(number)) return fallback
+  return Math.min(Math.max(Math.round(number), min), max)
+}
+
+function parseFiniteInteger(value, fallback) {
+  const number = Number(value)
+  return Number.isFinite(number) ? Math.round(number) : fallback
+}
+
+function parseFiniteNumber(value, fallback) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : fallback
+}
+
+function toDegrees(rotation) {
+  return Math.round((parseFiniteNumber(rotation, 0) * 180) / Math.PI)
+}
+
+function toRadians(degrees) {
+  return (parseFiniteNumber(degrees, 0) * Math.PI) / 180
+}
+
+function getSaveStateLabel(saveState) {
+  if (saveState === 'saving') return '保存中'
+  if (saveState === 'error') return '保存失败'
+  return '已保存'
+}
+
+function getShapeTypeLabel(shape) {
+  if (!shape) return ''
+  return shape.type
+}
+
+function triggerBlobDownload(blob, fileName) {
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = fileName
+  document.body.append(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}
+
+function getCurrentPageShapeIds(editor) {
+  return editor.getSortedChildIdsForParent(editor.getCurrentPageId())
+}
+
+function getSelectionShapeIds(editor) {
+  return editor.getSelectedShapeIds()
+}
+
+function getExportTargetShapeIds(editor, scope) {
+  if (scope === 'page') return getCurrentPageShapeIds(editor)
+
+  const selectedShapeIds = getSelectionShapeIds(editor)
+  if (selectedShapeIds.length > 0) return selectedShapeIds
+  return getCurrentPageShapeIds(editor)
+}
+
+function getExportTargetLabel(editor, scope = 'auto') {
+  const selectedShapeIds = getSelectionShapeIds(editor)
+  if (scope !== 'page' && selectedShapeIds.length > 0) {
+    return selectedShapeIds.length === 1 ? '当前选中对象' : `当前选中 ${selectedShapeIds.length} 个对象`
+  }
+
+  return `当前页面 ${editor.getCurrentPage().name}`
+}
+
+function getSharedStringValue(shapes, getter) {
+  if (shapes.length === 0) return null
+  const firstValue = getter(shapes[0])
+  if (typeof firstValue !== 'string') return null
+
+  for (const shape of shapes.slice(1)) {
+    if (getter(shape) !== firstValue) return null
+  }
+
+  return firstValue
+}
+
+function getRotationDegreesValue(shapes) {
+  if (shapes.length === 0) return null
+  const firstValue = toDegrees(shapes[0].rotation)
+
+  for (const shape of shapes.slice(1)) {
+    if (toDegrees(shape.rotation) !== firstValue) return null
+  }
+
+  return firstValue
+}
+
+function supportsPosition(shape) {
+  return Number.isFinite(Number(shape?.x)) && Number.isFinite(Number(shape?.y))
+}
+
+function supportsSize(shape) {
+  return Number.isFinite(Number(shape?.props?.w)) && Number.isFinite(Number(shape?.props?.h))
+}
+
+function supportsRotation(shape) {
+  return Number.isFinite(Number(shape?.rotation))
+}
+
+function supportsOpacity(shape) {
+  return Number.isFinite(Number(shape?.opacity ?? 1))
+}
+
+function supportsImageCornerRadius(shape) {
+  return shape?.type === 'image' && Number.isFinite(Number(shape?.props?.w)) && Number.isFinite(Number(shape?.props?.h))
+}
+
+function supportsFill(shape) {
+  return typeof shape?.props?.fill === 'string'
+}
+
+function supportsStrokeColor(shape) {
+  return typeof shape?.props?.color === 'string'
+}
+
+function supportsStrokeDash(shape) {
+  return typeof shape?.props?.dash === 'string'
+}
+
+function supportsStrokeSize(shape) {
+  return typeof shape?.props?.size === 'string'
+}
+
+function supportsFont(shape) {
+  return typeof shape?.props?.font === 'string'
+}
+
+function supportsHorizontalAlign(shape) {
+  return typeof shape?.props?.align === 'string'
+}
+
+function supportsTextAlign(shape) {
+  return typeof shape?.props?.textAlign === 'string'
+}
+
+function supportsVerticalAlign(shape) {
+  return typeof shape?.props?.verticalAlign === 'string'
+}
+
+function supportsLabelColor(shape) {
+  return typeof shape?.props?.labelColor === 'string'
+}
+
+function shouldShowTextStyleSection(shape) {
+  return shape?.type === 'text' || shape?.type === 'note'
+}
+
+function getImageCornerRadiusValue(shape) {
+  if (!supportsImageCornerRadius(shape)) return 0
+  const width = Number(shape.props?.w) || 0
+  const height = Number(shape.props?.h) || 0
+  const maxRadius = Math.max(0, Math.floor(Math.min(width, height) / 2))
+  const radius = Number(shape?.meta?.cowartImageCornerRadius ?? 0)
+  if (!Number.isFinite(radius)) return 0
+  return Math.min(Math.max(Math.round(radius), 0), maxRadius)
+}
+
+function getImageBorderWidthValue(shape) {
+  if (!supportsImageCornerRadius(shape)) return 0
+  const width = Number(shape?.meta?.cowartImageBorderWidth ?? 0)
+  if (!Number.isFinite(width)) return 0
+  return Math.min(Math.max(Math.round(width), 0), 24)
+}
+
+function getImageBorderColorValue(shape) {
+  if (!supportsImageCornerRadius(shape)) return 'black'
+  return resolveColorOptionValue(shape?.meta?.cowartImageBorderColor, SHAPE_COLOR_OPTIONS) ?? 'black'
+}
+
+function getImageShadowValue(shape) {
+  if (!supportsImageCornerRadius(shape)) return 0
+  const shadow = Number(shape?.meta?.cowartImageShadow ?? 0)
+  if (!Number.isFinite(shadow)) return 0
+  return Math.min(Math.max(Math.round(shadow), 0), 100)
+}
+
+function getImageBlurValue(shape) {
+  if (!supportsImageCornerRadius(shape)) return 0
+  const blur = Number(shape?.meta?.cowartImageBlur ?? 0)
+  if (!Number.isFinite(blur)) return 0
+  return Math.min(Math.max(Math.round(blur), 0), 40)
+}
+
+function getImageShadowColorValue(shape) {
+  if (!supportsImageCornerRadius(shape)) return 'black'
+  return resolveColorOptionValue(shape?.meta?.cowartImageShadowColor, SHAPE_COLOR_OPTIONS) ?? 'black'
+}
+
+function ColorControl({ label, value, onChange, options = SHAPE_COLOR_OPTIONS }) {
+  const [draftValue, setDraftValue] = useState(() => getColorDisplayValue(value, options))
+  const colorInputValue = resolveColorSwatch(value, options)
+
+  useEffect(() => {
+    setDraftValue(getColorDisplayValue(value, options))
+  }, [options, value])
+
+  function commitTextValue() {
+    const nextValue = resolveColorOptionValue(draftValue, options)
+    if (!nextValue) {
+      setDraftValue(getColorDisplayValue(value, options))
+      return
+    }
+
+    onChange(nextValue)
+  }
+
+  return (
+    <fieldset className="cowart-color-field cowart-color-field-compact">
+      <legend>{label}</legend>
+
+      <div className="cowart-color-input-row">
+        <input
+          className="cowart-color-native-input"
+          type="color"
+          value={colorInputValue}
+          aria-label={`${label}颜色选择`}
+          onChange={(event) => {
+            const nextValue = resolveColorOptionValue(event.target.value, options)
+            if (!nextValue) return
+            onChange(nextValue)
+          }}
+        />
+        <input
+          className="cowart-color-text-input"
+          type="text"
+          value={draftValue}
+          placeholder="#000000"
+          aria-label={`${label}颜色值`}
+          onChange={(event) => setDraftValue(event.target.value)}
+          onBlur={commitTextValue}
+          onKeyDown={(event) => {
+            if (event.key !== 'Enter') return
+            event.preventDefault()
+            commitTextValue()
+          }}
+        />
+      </div>
+    </fieldset>
+  )
+}
+
+function SegmentedControl({ label, value, options, onChange }) {
+  return (
+    <div className="cowart-segmented-control">
+      <span>{label}</span>
+      <div className="cowart-segmented-control-track" role="group" aria-label={label}>
+        {options.map((option) => (
+          <button
+            key={option.value}
+            className="cowart-segmented-control-button"
+            type="button"
+            data-active={value === option.value ? 'true' : 'false'}
+            onClick={() => onChange(option.value)}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function SelectionSection({ editor, selectedShapes }) {
+  const singleSelectedShape = selectedShapes.length === 1 ? selectedShapes[0] : null
+  const multipleSelectedShapes = selectedShapes.length > 1 ? selectedShapes : []
+  const [isAspectRatioLocked, setIsAspectRatioLocked] = useState(true)
+  const canEditPosition = supportsPosition(singleSelectedShape)
+  const canEditSize = supportsSize(singleSelectedShape)
+  const canEditRotation = supportsRotation(singleSelectedShape)
+  const selectedX = parseFiniteInteger(singleSelectedShape?.x, 0)
+  const selectedY = parseFiniteInteger(singleSelectedShape?.y, 0)
+  const selectedWidth = clampNumber(singleSelectedShape?.props?.w, 1, 100000, 0)
+  const selectedHeight = clampNumber(singleSelectedShape?.props?.h, 1, 100000, 0)
+  const selectedRotation = canEditRotation ? toDegrees(singleSelectedShape.rotation) : 0
+  const selectedOpacityPercent = singleSelectedShape
+    ? Math.round((Number(singleSelectedShape.opacity ?? 1) || 1) * 100)
+    : 100
+  const selectedImageCornerRadius = getImageCornerRadiusValue(singleSelectedShape)
+  const selectedImageBorderWidth = getImageBorderWidthValue(singleSelectedShape)
+  const selectedImageBorderColor = getImageBorderColorValue(singleSelectedShape)
+  const selectedImageShadow = getImageShadowValue(singleSelectedShape)
+  const selectedImageBlur = getImageBlurValue(singleSelectedShape)
+  const selectedImageShadowColor = getImageShadowColorValue(singleSelectedShape)
+
+  const sharedFill = getSharedStringValue(multipleSelectedShapes, (shape) => shape.props?.fill)
+  const sharedStrokeColor = getSharedStringValue(multipleSelectedShapes, (shape) => shape.props?.color)
+  const sharedStrokeDash = getSharedStringValue(multipleSelectedShapes, (shape) => shape.props?.dash)
+  const sharedStrokeSize = getSharedStringValue(multipleSelectedShapes, (shape) => shape.props?.size)
+  const sharedRotation = getRotationDegreesValue(multipleSelectedShapes)
+
+  const canBatchFill = multipleSelectedShapes.length > 0 && multipleSelectedShapes.every(supportsFill)
+  const canBatchStrokeColor =
+    multipleSelectedShapes.length > 0 && multipleSelectedShapes.every(supportsStrokeColor)
+  const canBatchStrokeDash =
+    multipleSelectedShapes.length > 0 && multipleSelectedShapes.every(supportsStrokeDash)
+  const canBatchStrokeSize =
+    multipleSelectedShapes.length > 0 && multipleSelectedShapes.every(supportsStrokeSize)
+
+  function updateSingleShape(update) {
+    if (!editor || !singleSelectedShape) return
+    editor.updateShapes([
+      {
+        id: singleSelectedShape.id,
+        type: singleSelectedShape.type,
+        ...update
+      }
+    ])
+  }
+
+  function updateMultipleShapes(updateFactory) {
+    if (!editor || multipleSelectedShapes.length === 0) return
+    editor.updateShapes(
+      multipleSelectedShapes.map((shape) => ({
+        id: shape.id,
+        type: shape.type,
+        ...updateFactory(shape)
+      }))
+    )
+  }
+
+  function updateSingleShapePosition(partialPosition) {
+    updateSingleShape({
+      x: parseFiniteInteger(partialPosition.x ?? singleSelectedShape.x, selectedX),
+      y: parseFiniteInteger(partialPosition.y ?? singleSelectedShape.y, selectedY)
+    })
+  }
+
+  function updateSingleShapeOpacity(value) {
+    updateSingleShape({
+      opacity: clampNumber(value, 0, 100, 100) / 100
+    })
+  }
+
+  function updateSingleShapeSize(partialProps) {
+    const currentWidth = selectedWidth || 1
+    const currentHeight = selectedHeight || 1
+    const ratio = currentHeight === 0 ? 1 : currentWidth / currentHeight
+    let nextWidth = clampNumber(partialProps.w ?? singleSelectedShape.props?.w, 1, 100000, currentWidth)
+    let nextHeight = clampNumber(partialProps.h ?? singleSelectedShape.props?.h, 1, 100000, currentHeight)
+
+    if (isAspectRatioLocked && supportsSize(singleSelectedShape)) {
+      if (partialProps.w !== undefined && partialProps.h === undefined) {
+        nextHeight = clampNumber(nextWidth / (ratio || 1), 1, 100000, currentHeight)
+      }
+
+      if (partialProps.h !== undefined && partialProps.w === undefined) {
+        nextWidth = clampNumber(nextHeight * (ratio || 1), 1, 100000, currentWidth)
+      }
+    }
+
+    updateSingleShape({
+      props: {
+        ...singleSelectedShape.props,
+        ...partialProps,
+        w: nextWidth,
+        h: nextHeight
+      }
+    })
+  }
+
+  function updateSingleShapeStyle(partialProps) {
+    updateSingleShape({
+      props: {
+        ...singleSelectedShape.props,
+        ...partialProps
+      }
+    })
+  }
+
+  function updateSingleShapeMeta(partialMeta) {
+    updateSingleShape({
+      meta: {
+        ...(singleSelectedShape.meta ?? {}),
+        ...partialMeta
+      }
+    })
+  }
+
+  function updateBatchStyle(partialProps) {
+    updateMultipleShapes((shape) => ({
+      props: {
+        ...shape.props,
+        ...partialProps
+      }
+    }))
+  }
+
+  function updateBatchRotation(value) {
+    updateMultipleShapes(() => ({
+      rotation: toRadians(value)
+    }))
+  }
+
+  return (
+    <section className="cowart-inspector-section" aria-label="选中对象">
+      {singleSelectedShape ? (
+        <>
+          <div className="cowart-selection-meta">
+            <span className="cowart-selection-chip">{getShapeTypeLabel(singleSelectedShape)}</span>
+            <strong>当前对象</strong>
+          </div>
+
+          <section className="cowart-property-group cowart-property-group-geometry" aria-label="对象几何">
+            <div className="cowart-property-group-header">
+              <h4>变换</h4>
+            </div>
+            <div className="cowart-object-transform-grid">
+              <label className="cowart-transform-field">
+                <span>X</span>
+                <input
+                  type="number"
+                  step="1"
+                  value={canEditPosition ? selectedX : ''}
+                  placeholder="--"
+                  disabled={!canEditPosition}
+                  onChange={(event) => updateSingleShapePosition({ x: event.target.value })}
+                />
+              </label>
+              <label className="cowart-transform-field">
+                <span>Y</span>
+                <input
+                  type="number"
+                  step="1"
+                  value={canEditPosition ? selectedY : ''}
+                  placeholder="--"
+                  disabled={!canEditPosition}
+                  onChange={(event) => updateSingleShapePosition({ y: event.target.value })}
+                />
+              </label>
+
+              <label className="cowart-transform-field">
+                <span>W</span>
+                <input
+                  type="number"
+                  min="1"
+                  step="1"
+                  value={canEditSize ? selectedWidth : ''}
+                  placeholder="--"
+                  disabled={!canEditSize}
+                  onChange={(event) => updateSingleShapeSize({ w: event.target.value })}
+                />
+              </label>
+              <label className="cowart-transform-field">
+                <span>H</span>
+                <input
+                  type="number"
+                  min="1"
+                  step="1"
+                  value={canEditSize ? selectedHeight : ''}
+                  placeholder="--"
+                  disabled={!canEditSize}
+                  onChange={(event) => updateSingleShapeSize({ h: event.target.value })}
+                />
+              </label>
+
+              <label className="cowart-transform-field">
+                <span>R</span>
+                <input
+                  type="number"
+                  step="1"
+                  value={canEditRotation ? selectedRotation : ''}
+                  placeholder="--"
+                  disabled={!canEditRotation}
+                  onChange={(event) =>
+                    updateSingleShape({
+                      rotation: toRadians(event.target.value)
+                    })
+                  }
+                />
+              </label>
+
+              <button
+                className="cowart-transform-icon-button"
+                type="button"
+                aria-pressed={canEditSize && isAspectRatioLocked ? 'true' : 'false'}
+                title={canEditSize ? (isAspectRatioLocked ? '已锁定宽高比例' : '未锁定宽高比例') : '当前对象不支持宽高比例锁定'}
+                disabled={!canEditSize}
+                onClick={() => setIsAspectRatioLocked((value) => !value)}
+              >
+                {isAspectRatioLocked ? '🔒' : '🔓'}
+              </button>
+
+              {!canEditSize && (
+                <p className="cowart-section-empty cowart-transform-note">这个对象暂时不支持直接编辑宽高。</p>
+              )}
+            </div>
+          </section>
+
+          <StyleSection
+            title="样式"
+            shape={singleSelectedShape}
+            opacityPercent={selectedOpacityPercent}
+            imageCornerRadius={selectedImageCornerRadius}
+            imageBorderWidth={selectedImageBorderWidth}
+            imageBorderColor={selectedImageBorderColor}
+            imageShadow={selectedImageShadow}
+            imageBlur={selectedImageBlur}
+            imageShadowColor={selectedImageShadowColor}
+            canEditOpacity={supportsOpacity(singleSelectedShape)}
+            onChangeOpacity={updateSingleShapeOpacity}
+            onChangeMeta={updateSingleShapeMeta}
+            onChangeStyle={updateSingleShapeStyle}
+          />
+
+          <TextStyleSection shape={singleSelectedShape} onChangeStyle={updateSingleShapeStyle} />
+        </>
+      ) : multipleSelectedShapes.length > 1 ? (
+        <>
+          <p className="cowart-section-note">已选中 {multipleSelectedShapes.length} 个对象。</p>
+
+          <section className="cowart-subsection">
+            <div className="cowart-section-subtitle">批量几何与样式</div>
+
+            <label className="cowart-setting-stack">
+              <span>旋转</span>
+              <input
+                type="number"
+                step="1"
+                value={sharedRotation ?? ''}
+                placeholder="混合值"
+                onChange={(event) => updateBatchRotation(event.target.value)}
+              />
+            </label>
+
+            {canBatchFill && (
+              <label className="cowart-setting-stack">
+                <span>填充</span>
+                <select
+                  value={sharedFill ?? ''}
+                  onChange={(event) => updateBatchStyle({ fill: event.target.value })}
+                >
+                  <option value="">混合值</option>
+                  {FILL_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+
+            {canBatchStrokeDash && (
+              <label className="cowart-setting-stack">
+                <span>描边样式</span>
+                <select
+                  value={sharedStrokeDash ?? ''}
+                  onChange={(event) => updateBatchStyle({ dash: event.target.value })}
+                >
+                  <option value="">混合值</option>
+                  {DASH_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+
+            {canBatchStrokeSize && (
+              <label className="cowart-setting-stack">
+                <span>描边粗细</span>
+                <select
+                  value={sharedStrokeSize ?? ''}
+                  onChange={(event) => updateBatchStyle({ size: event.target.value })}
+                >
+                  <option value="">混合值</option>
+                  {SIZE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+
+            {canBatchStrokeColor && (
+              <ColorControl
+                label="描边颜色"
+                value={sharedStrokeColor ?? ''}
+                onChange={(color) => updateBatchStyle({ color })}
+              />
+            )}
+
+            {!canBatchFill && !canBatchStrokeDash && !canBatchStrokeSize && !canBatchStrokeColor && (
+              <p className="cowart-section-empty">当前多选对象没有可安全批量应用的共有样式字段。</p>
+            )}
+          </section>
+        </>
+      ) : (
+        <p className="cowart-section-empty">
+          选中单个图形后，可以调整位置、尺寸、旋转、样式和文本；多选时会出现批量样式和批量旋转。
+        </p>
+      )}
+    </section>
+  )
+}
+
+function StyleSection({
+  title,
+  shape,
+  opacityPercent,
+  imageCornerRadius,
+  imageBorderWidth,
+  imageBorderColor,
+  imageShadow,
+  imageBlur,
+  imageShadowColor,
+  canEditOpacity,
+  onChangeOpacity,
+  onChangeMeta,
+  onChangeStyle
+}) {
+  const canEditFill = supportsFill(shape)
+  const canEditStrokeColor = supportsStrokeColor(shape)
+  const canEditStrokeDash = supportsStrokeDash(shape)
+  const canEditStrokeSize = supportsStrokeSize(shape)
+  const canEditImageCornerRadius = supportsImageCornerRadius(shape)
+  const canRenderOpacityRow = canEditOpacity && !canEditFill
+  const canRenderSection =
+    canEditFill ||
+    canEditStrokeDash ||
+    canEditStrokeSize ||
+    canEditStrokeColor ||
+    canRenderOpacityRow ||
+    canEditImageCornerRadius
+
+  if (!canRenderSection) return null
+
+  return (
+    <section className="cowart-property-group cowart-property-group-styles">
+      <div className="cowart-property-group-header">
+        <h4>{title}</h4>
+      </div>
+
+      {canEditFill && (
+        <div className="cowart-property-row cowart-property-row-compact">
+          <span className="cowart-property-label">填充</span>
+
+          {canEditStrokeColor && (
+            <ColorControl label="颜色" value={shape.props.color} onChange={(color) => onChangeStyle({ color })} />
+          )}
+
+          <div className="cowart-inline-control-row">
+            <label className="cowart-compact-select cowart-compact-select-surface">
+              <span>样式</span>
+              <select value={shape.props.fill} onChange={(event) => onChangeStyle({ fill: event.target.value })}>
+                {FILL_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            {canEditOpacity ? (
+              <label className="cowart-compact-select cowart-compact-select-surface">
+                <span>不透明度</span>
+                <div className="cowart-input-with-suffix">
+                  <input
+                    type="number"
+                    min="0"
+                    max="100"
+                    step="1"
+                    value={opacityPercent}
+                    onChange={(event) => onChangeOpacity(event.target.value)}
+                  />
+                  <em>%</em>
+                </div>
+              </label>
+            ) : null}
+          </div>
+        </div>
+      )}
+
+      {canRenderOpacityRow && (
+        <div className="cowart-property-row cowart-property-row-compact">
+          <span className="cowart-property-label">外观</span>
+          <div className="cowart-inline-control-row">
+            <label className="cowart-compact-select cowart-compact-select-surface">
+              <span>不透明度</span>
+              <div className="cowart-input-with-suffix">
+                <input
+                  type="number"
+                  min="0"
+                  max="100"
+                  step="1"
+                  value={opacityPercent}
+                  onChange={(event) => onChangeOpacity(event.target.value)}
+                />
+                <em>%</em>
+              </div>
+            </label>
+
+            {canEditImageCornerRadius ? (
+              <label className="cowart-compact-select cowart-compact-select-surface">
+                <span>圆角</span>
+                <div className="cowart-input-with-suffix">
+                  <input
+                    type="number"
+                    min="0"
+                    max={Math.max(0, Math.floor(Math.min(shape.props.w, shape.props.h) / 2))}
+                    step="1"
+                    value={imageCornerRadius}
+                    onChange={(event) =>
+                      onChangeMeta({
+                        cowartImageCornerRadius: clampNumber(
+                          event.target.value,
+                          0,
+                          Math.max(0, Math.floor(Math.min(shape.props.w, shape.props.h) / 2)),
+                          imageCornerRadius
+                        )
+                      })
+                    }
+                  />
+                  <em>px</em>
+                </div>
+              </label>
+            ) : null}
+          </div>
+
+          {canEditImageCornerRadius ? (
+            <>
+              <div className="cowart-inline-control-row">
+                <label className="cowart-compact-select cowart-compact-select-surface">
+                  <span>边框粗细</span>
+                  <div className="cowart-input-with-suffix">
+                    <input
+                      type="number"
+                      min="0"
+                      max="24"
+                      step="1"
+                      value={imageBorderWidth}
+                      onChange={(event) =>
+                        onChangeMeta({
+                          cowartImageBorderWidth: clampNumber(event.target.value, 0, 24, imageBorderWidth)
+                        })
+                      }
+                    />
+                    <em>px</em>
+                  </div>
+                </label>
+
+                <label className="cowart-compact-select cowart-compact-select-surface">
+                  <span>阴影</span>
+                  <div className="cowart-input-with-suffix">
+                    <input
+                      type="number"
+                      min="0"
+                      max="100"
+                      step="1"
+                      value={imageShadow}
+                      onChange={(event) =>
+                        onChangeMeta({
+                          cowartImageShadow: clampNumber(event.target.value, 0, 100, imageShadow)
+                        })
+                      }
+                    />
+                    <em>%</em>
+                  </div>
+                </label>
+              </div>
+
+              <div className="cowart-inline-control-row">
+                <label className="cowart-compact-select cowart-compact-select-surface">
+                  <span>模糊</span>
+                  <div className="cowart-input-with-suffix">
+                    <input
+                      type="number"
+                      min="0"
+                      max="40"
+                      step="1"
+                      value={imageBlur}
+                      onChange={(event) =>
+                        onChangeMeta({
+                          cowartImageBlur: clampNumber(event.target.value, 0, 40, imageBlur)
+                        })
+                      }
+                    />
+                    <em>px</em>
+                  </div>
+                </label>
+
+                <div />
+              </div>
+
+              <ColorControl
+                label="边框颜色"
+                value={imageBorderColor}
+                onChange={(color) =>
+                  onChangeMeta({
+                    cowartImageBorderColor: color
+                  })
+                }
+              />
+
+              <ColorControl
+                label="阴影颜色"
+                value={imageShadowColor}
+                onChange={(color) =>
+                  onChangeMeta({
+                    cowartImageShadowColor: color
+                  })
+                }
+              />
+            </>
+          ) : null}
+        </div>
+      )}
+
+      {(canEditStrokeDash || canEditStrokeSize || canEditStrokeColor) && (
+        <div className="cowart-property-row cowart-property-row-compact">
+          <span className="cowart-property-label">描边</span>
+
+          <div className="cowart-inline-control-row">
+            {canEditStrokeDash && (
+              <label className="cowart-compact-select cowart-compact-select-surface">
+                <span>样式</span>
+                <select value={shape.props.dash} onChange={(event) => onChangeStyle({ dash: event.target.value })}>
+                  {DASH_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+
+            {canEditStrokeSize && (
+              <label className="cowart-compact-select cowart-compact-select-surface">
+                <span>粗细</span>
+                <select value={shape.props.size} onChange={(event) => onChangeStyle({ size: event.target.value })}>
+                  {SIZE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function TextStyleSection({ shape, onChangeStyle }) {
+  const shouldRenderTextSection = shouldShowTextStyleSection(shape)
+  const canEditFont = supportsFont(shape)
+  const canEditHorizontalAlign = supportsHorizontalAlign(shape)
+  const canEditTextAlign = supportsTextAlign(shape)
+  const canEditVerticalAlign = supportsVerticalAlign(shape)
+  const canEditLabelColor = supportsLabelColor(shape)
+
+  if (!shouldRenderTextSection) return null
+
+  return (
+    <section className="cowart-property-group cowart-property-group-text">
+      <div className="cowart-property-group-header">
+        <h4>文字</h4>
+      </div>
+
+      {(canEditFont || canEditHorizontalAlign || canEditTextAlign || canEditVerticalAlign) && (
+        <div className="cowart-text-control-stack">
+          {canEditFont && (
+            <label className="cowart-compact-select cowart-compact-select-surface">
+              <span>字体</span>
+              <select value={shape.props.font} onChange={(event) => onChangeStyle({ font: event.target.value })}>
+                {FONT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+
+          {(canEditHorizontalAlign || canEditTextAlign || canEditVerticalAlign) && (
+            <div className="cowart-text-segment-grid">
+              {canEditHorizontalAlign && (
+                <SegmentedControl
+                  label="水平"
+                  value={shape.props.align}
+                  options={HORIZONTAL_ALIGN_BUTTONS}
+                  onChange={(align) => onChangeStyle({ align })}
+                />
+              )}
+
+              {canEditTextAlign && (
+                <SegmentedControl
+                  label="文本"
+                  value={shape.props.textAlign}
+                  options={TEXT_ALIGN_BUTTONS}
+                  onChange={(textAlign) => onChangeStyle({ textAlign })}
+                />
+              )}
+
+              {canEditVerticalAlign && (
+                <SegmentedControl
+                  label="垂直"
+                  value={shape.props.verticalAlign}
+                  options={VERTICAL_ALIGN_BUTTONS}
+                  onChange={(verticalAlign) => onChangeStyle({ verticalAlign })}
+                />
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {canEditLabelColor && (
+        <ColorControl
+          label="文字颜色"
+          value={shape.props.labelColor}
+          onChange={(labelColor) => onChangeStyle({ labelColor })}
+        />
+      )}
+
+      {!canEditFont &&
+        !canEditHorizontalAlign &&
+        !canEditTextAlign &&
+        !canEditVerticalAlign &&
+        !canEditLabelColor && (
+          <p className="cowart-section-empty">这个对象暂时没有可在右侧栏编辑的文字样式字段。</p>
+        )}
+    </section>
+  )
+}
+
+function CanvasSettingsSection({
+  settings,
+  onChangeSettings,
+  onResetSettings,
+  annotationColorOptions
+}) {
+  const currentColor =
+    annotationColorOptions.find((option) => option.value === settings.annotationColor) ??
+    annotationColorOptions[0]
+
+  return (
+    <section className="cowart-inspector-section" aria-label="画板设置">
+      <div className="cowart-selection-meta">
+        <span className="cowart-selection-chip">canvas</span>
+        <strong>当前画板</strong>
+      </div>
+
+      <section className="cowart-property-group cowart-property-group-canvas">
+        <div className="cowart-property-group-header">
+          <h4>显示</h4>
+        </div>
+
+        <label className="cowart-setting-row cowart-setting-row-surface">
+          <span>背景色</span>
+          <input
+            type="color"
+            value={settings.backgroundColor}
+            onChange={(event) => onChangeSettings({ backgroundColor: event.target.value })}
+            aria-label="背景色"
+          />
+        </label>
+
+        <label className="cowart-setting-switch cowart-setting-switch-surface">
+          <span>显示网格</span>
+          <input
+            type="checkbox"
+            checked={settings.showGrid}
+            onChange={(event) => onChangeSettings({ showGrid: event.target.checked })}
+          />
+        </label>
+      </section>
+
+      <section className="cowart-property-group cowart-property-group-canvas">
+        <div className="cowart-property-group-header">
+          <h4>默认尺寸</h4>
+        </div>
+
+        <div className="cowart-setting-grid cowart-setting-grid-surface" aria-label="AI 图片默认尺寸">
+          <label>
+            <span>宽</span>
+            <input
+              type="number"
+              min="80"
+              max="2400"
+              step="10"
+              value={settings.aiImageHolderWidth}
+              onChange={(event) => onChangeSettings({ aiImageHolderWidth: event.target.value })}
+            />
+          </label>
+          <label>
+            <span>高</span>
+            <input
+              type="number"
+              min="80"
+              max="2400"
+              step="10"
+              value={settings.aiImageHolderHeight}
+              onChange={(event) => onChangeSettings({ aiImageHolderHeight: event.target.value })}
+            />
+          </label>
+        </div>
+      </section>
+
+      <section className="cowart-property-group cowart-property-group-canvas">
+        <div className="cowart-property-group-header">
+          <h4>批注</h4>
+        </div>
+
+        <ColorControl
+          label="批注颜色"
+          value={currentColor.value}
+          options={annotationColorOptions}
+          onChange={(annotationColor) => onChangeSettings({ annotationColor })}
+        />
+      </section>
+
+      <button className="cowart-settings-reset cowart-settings-reset-surface" type="button" onClick={onResetSettings}>
+        恢复默认
+      </button>
+    </section>
+  )
+}
+
+function ExportSection({ editor }) {
+  const [format, setFormat] = useState('png')
+  const [scale, setScale] = useState(2)
+  const [includeBackground, setIncludeBackground] = useState(true)
+  const [isExporting, setIsExporting] = useState(false)
+  const [exportMessage, setExportMessage] = useState('')
+
+  async function runExport({ format: nextFormat, scale: nextScale, background, scope = 'auto' }) {
+    if (!editor) return
+
+    const shapeIds = getExportTargetShapeIds(editor, scope)
+    if (shapeIds.length === 0) {
+      setExportMessage('当前页面没有可导出的内容。')
+      return
+    }
+
+    setIsExporting(true)
+    setExportMessage('')
+
+    try {
+      const result = await editor.toImage(shapeIds, {
+        format: nextFormat,
+        scale: nextScale,
+        background
+      })
+
+      const fileBaseName =
+        scope === 'page'
+          ? `cowart-page-${editor.getCurrentPage().name}-${Date.now()}`
+          : editor.getSelectedShapeIds().length > 0
+            ? `cowart-selection-${Date.now()}`
+            : `cowart-page-${editor.getCurrentPage().name}-${Date.now()}`
+
+      triggerBlobDownload(result.blob, `${fileBaseName}.${nextFormat}`)
+      setExportMessage(`已导出${getExportTargetLabel(editor, scope)}。`)
+    } catch (error) {
+      console.error(error)
+      setExportMessage('导出失败，请重试。')
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  return (
+    <section className="cowart-inspector-section cowart-inspector-section-compact" aria-label="导出">
+      <div className="cowart-style-stack">
+        <div className="cowart-property-group-header">
+          <h4>导出</h4>
+        </div>
+        <div className="cowart-preset-grid">
+          {EXPORT_PRESET_OPTIONS.map((preset) => (
+            <button
+              key={preset.value}
+              className="cowart-preset-button"
+              type="button"
+              disabled={!editor || (preset.scope === 'selection' && getSelectionShapeIds(editor).length === 0) || isExporting}
+              onClick={() => runExport(preset)}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <p className="cowart-section-note">
+        {editor ? `导出目标：${getExportTargetLabel(editor)}` : '画布加载后可导出当前选中对象或当前页面。'}
+      </p>
+
+      <div className="cowart-inline-control-row">
+        <label className="cowart-setting-stack">
+          <span>格式</span>
+          <select value={format} onChange={(event) => setFormat(event.target.value)}>
+            {EXPORT_FORMAT_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="cowart-setting-stack">
+          <span>倍率</span>
+          <select value={scale} onChange={(event) => setScale(Number(event.target.value))}>
+            {EXPORT_SCALE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <label className="cowart-setting-switch cowart-setting-switch-surface">
+        <span>导出画板背景</span>
+        <input
+          type="checkbox"
+          checked={includeBackground}
+          onChange={(event) => setIncludeBackground(event.target.checked)}
+        />
+      </label>
+
+      <button
+        className="cowart-primary-action"
+        type="button"
+        onClick={() =>
+          runExport({
+            format,
+            scale,
+            background: includeBackground
+          })
+        }
+        disabled={!editor || isExporting}
+      >
+        {isExporting ? '导出中...' : '自定义导出'}
+      </button>
+
+      {exportMessage ? <p className="cowart-section-note">{exportMessage}</p> : null}
+    </section>
+  )
+}
+
+export default function CowartInspector({
+  editor,
+  selectedShapes,
+  settings,
+  saveState,
+  onChangeSettings,
+  onResetSettings,
+  annotationColorOptions
+}) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [activeTab, setActiveTab] = useState('selection')
+
+  function handleToggleInspector() {
+    if (isOpen) {
+      setIsOpen(false)
+      return
+    }
+
+    setActiveTab(selectedShapes.length > 0 ? 'selection' : 'canvas')
+    setIsOpen(true)
+  }
+
+  return (
+    <section
+      className={`cowart-inspector ${isOpen ? 'cowart-inspector-open' : ''}`}
+      aria-label="右侧属性面板"
+    >
+      <button
+        className="cowart-inspector-toggle"
+        type="button"
+        aria-expanded={isOpen}
+        aria-controls="cowart-inspector-panel"
+        onClick={handleToggleInspector}
+        title={isOpen ? '关闭右侧栏' : '打开右侧栏'}
+      >
+        <span aria-hidden="true">{isOpen ? '×' : '☰'}</span>
+      </button>
+
+      {isOpen && (
+        <aside
+          id="cowart-inspector-panel"
+          className="cowart-inspector-panel"
+          aria-label="画板和属性设置"
+        >
+          <header className="cowart-inspector-header">
+            <div className="cowart-inspector-header-copy">
+              <h2>属性</h2>
+              <p>对象与画板设置</p>
+            </div>
+            <span className="cowart-save-badge">{getSaveStateLabel(saveState)}</span>
+            <button
+              className="cowart-inspector-close"
+              type="button"
+              onClick={() => setIsOpen(false)}
+              aria-label="关闭右侧栏"
+              title="关闭"
+            >
+              ×
+            </button>
+          </header>
+
+          <div className="cowart-inspector-body">
+            <div className="cowart-inspector-tabs" role="tablist" aria-label="右侧栏内容切换">
+              <button
+                className="cowart-inspector-tab"
+                type="button"
+                role="tab"
+                aria-selected={activeTab === 'selection'}
+                data-active={activeTab === 'selection' ? 'true' : 'false'}
+                onClick={() => setActiveTab('selection')}
+              >
+                对象
+              </button>
+              <button
+                className="cowart-inspector-tab"
+                type="button"
+                role="tab"
+                aria-selected={activeTab === 'canvas'}
+                data-active={activeTab === 'canvas' ? 'true' : 'false'}
+                onClick={() => setActiveTab('canvas')}
+              >
+                画板
+              </button>
+            </div>
+
+            {activeTab === 'selection' ? (
+              <>
+                <SelectionSection editor={editor} selectedShapes={selectedShapes} />
+                <ExportSection editor={editor} />
+              </>
+            ) : (
+              <CanvasSettingsSection
+                settings={settings}
+                onChangeSettings={onChangeSettings}
+                onResetSettings={onResetSettings}
+                annotationColorOptions={annotationColorOptions}
+              />
+            )}
+          </div>
+        </aside>
+      )}
+    </section>
+  )
+}

--- a/src/components/CowartTextShapeUtils.jsx
+++ b/src/components/CowartTextShapeUtils.jsx
@@ -1,0 +1,489 @@
+import { useCallback } from 'react'
+import {
+  Box,
+  RichTextLabel,
+  RichTextSVG,
+  TextShapeUtil,
+  NoteShapeUtil,
+  createComputedCache,
+  getColorValue,
+  getDisplayValues,
+  isEqual,
+  renderHtmlFromRichText,
+  renderHtmlFromRichTextForMeasurement,
+  toRichText,
+  useColorMode,
+  useEditor
+} from 'tldraw'
+import {
+  getCowartFontFamily,
+  getCowartFontKey,
+  getCowartFontSize
+} from './cowartTextStyles.js'
+
+const TEXT_PROPS = {
+  fontWeight: 'normal',
+  fontVariant: 'normal',
+  fontStyle: 'normal'
+}
+
+const noteHorizontalAligns = {
+  start: 'start',
+  middle: 'center',
+  end: 'end',
+  'start-legacy': 'start',
+  'end-legacy': 'end',
+  'middle-legacy': 'center'
+}
+
+const noteVerticalAligns = {
+  start: 'start',
+  middle: 'middle',
+  end: 'end'
+}
+
+const textSizeCache = createComputedCache(
+  'cowart text size',
+  (editor, shape) => {
+    const util = editor.getShapeUtil(shape)
+    const dv = getDisplayValues(util, shape)
+    return getCowartTextSize(editor, shape.props, dv)
+  },
+  { areRecordsEqual: (a, b) => a.props === b.props && a.meta === b.meta }
+)
+
+function getTextColor(shape, theme, colorMode) {
+  const colors = theme.colors[colorMode]
+  if (shape.type === 'text') {
+    return getColorValue(colors, shape.props.color, 'solid')
+  }
+
+  return shape.props.labelColor === 'black'
+    ? getColorValue(colors, shape.props.color, 'noteText')
+    : getColorValue(colors, shape.props.labelColor, 'fill')
+}
+
+function getTextWeight(shape) {
+  const weight = Number(shape?.meta?.cowartTextFontWeight ?? 400)
+  if (!Number.isFinite(weight)) return 400
+  return Math.min(Math.max(Math.round(weight), 100), 900)
+}
+
+function getTextItalic(shape) {
+  return shape?.meta?.cowartTextItalic === true
+}
+
+function getTextLineHeight(shape, fallback) {
+  const lineHeight = Number(shape?.meta?.cowartTextLineHeight ?? fallback)
+  if (!Number.isFinite(lineHeight)) return fallback
+  return Math.min(Math.max(lineHeight, 0.8), 3)
+}
+
+function getTextLetterSpacing(shape) {
+  const spacing = Number(shape?.meta?.cowartTextLetterSpacing ?? 0)
+  if (!Number.isFinite(spacing)) return 0
+  return Math.min(Math.max(Math.round(spacing * 10) / 10, -8), 40)
+}
+
+function getTextDecoration(shape) {
+  const decorations = []
+  if (shape?.meta?.cowartTextUnderline === true) decorations.push('underline')
+  if (shape?.meta?.cowartTextStrike === true) decorations.push('line-through')
+  return decorations.length ? decorations.join(' ') : 'none'
+}
+
+function getCowartTextDisplayValues(shape, theme, colorMode) {
+  const fontSize = getCowartFontSize(shape)
+  return {
+    color: getTextColor(shape, theme, colorMode),
+    fontFamily: getCowartFontFamily(getCowartFontKey(shape), shape.props.font),
+    fontSize,
+    lineHeight: getTextLineHeight(shape, theme.lineHeight),
+    fontWeight: `${getTextWeight(shape)}`,
+    fontStyle: getTextItalic(shape) ? 'italic' : TEXT_PROPS.fontStyle,
+    fontVariant: TEXT_PROPS.fontVariant,
+    letterSpacing: getTextLetterSpacing(shape),
+    textDecoration: getTextDecoration(shape)
+  }
+}
+
+function getCowartTextSize(editor, props, dv) {
+  const richText = props.richText
+  const minWidth = 16
+  const maybeFixedWidth = props.autoSize ? null : Math.max(minWidth, Math.floor(props.w))
+  const html = renderHtmlFromRichTextForMeasurement(editor, richText)
+  const result = editor.textMeasure.measureHtml(html, {
+    lineHeight: dv.lineHeight,
+    fontWeight: dv.fontWeight,
+    fontStyle: dv.fontStyle,
+    padding: '0px',
+    fontFamily: dv.fontFamily,
+    fontSize: dv.fontSize,
+    maxWidth: maybeFixedWidth,
+    otherStyles: {
+      'letter-spacing': `${dv.letterSpacing}px`
+    }
+  })
+
+  return {
+    width: maybeFixedWidth ?? Math.max(minWidth, result.w + 1),
+    height: Math.max(dv.fontSize, result.h)
+  }
+}
+
+function getNoteHeight(shape, noteHeight) {
+  return (noteHeight + shape.props.growY) * shape.props.scale
+}
+
+function getTextRenderStyle(dv, scale = 1) {
+  return {
+    fontWeight: dv.fontWeight,
+    fontStyle: dv.fontStyle,
+    letterSpacing: `${dv.letterSpacing}px`,
+    textDecoration: dv.textDecoration,
+    transform: `scale(${scale})`,
+    transformOrigin: 'top left'
+  }
+}
+
+function CowartRichTextSvg({
+  bounds,
+  richText,
+  fontSize,
+  fontFamily,
+  lineHeight,
+  textAlign,
+  verticalAlign,
+  wrap,
+  labelColor,
+  padding,
+  fontWeight,
+  fontStyle,
+  letterSpacing,
+  textDecoration,
+  showTextOutline = true
+}) {
+  const editor = useEditor()
+  const html = renderHtmlFromRichText(editor, richText)
+  const justifyContent = textAlign === 'center' ? 'center' : textAlign === 'start' ? 'flex-start' : 'flex-end'
+  const alignItems = verticalAlign === 'middle' ? 'center' : verticalAlign === 'start' ? 'flex-start' : 'flex-end'
+
+  return (
+    <foreignObject
+      x={bounds.minX}
+      y={bounds.minY}
+      width={bounds.w}
+      height={bounds.h}
+      className={showTextOutline ? 'tl-export-embed-styles tl-rich-text tl-text__outline' : 'tl-export-embed-styles tl-rich-text tl-text__no-outline'}
+    >
+      <div
+        style={{
+          display: 'flex',
+          fontFamily,
+          height: '100%',
+          justifyContent,
+          alignItems,
+          padding: `${padding}px`
+        }}
+      >
+        <div
+          dangerouslySetInnerHTML={{ __html: html }}
+          style={{
+            fontSize: `${fontSize}px`,
+            wrap: wrap ? 'wrap' : 'nowrap',
+            color: labelColor,
+            lineHeight,
+            textAlign,
+            width: '100%',
+            wordWrap: 'break-word',
+            overflowWrap: 'break-word',
+            whiteSpace: 'pre-wrap',
+            textShadow: showTextOutline ? 'var(--tl-text-outline)' : 'none',
+            tabSize: 'var(--tl-tab-size, 2)',
+            fontWeight,
+            fontStyle,
+            letterSpacing: `${letterSpacing}px`,
+            textDecoration
+          }}
+        />
+      </div>
+    </foreignObject>
+  )
+}
+
+function useTextShapeKeydownHandler(id) {
+  const editor = useEditor()
+
+  return useCallback(
+    (event) => {
+      if (editor.getEditingShapeId() !== id) return
+      if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+        editor.complete()
+      }
+    },
+    [editor, id]
+  )
+}
+
+export class CowartTextShapeUtil extends TextShapeUtil {
+  options = {
+    ...this.options,
+    getDefaultDisplayValues: (_editor, shape, theme, colorMode) =>
+      getCowartTextDisplayValues(shape, theme, colorMode)
+  }
+
+  getDefaultProps() {
+    return {
+      color: 'black',
+      size: 'm',
+      w: 8,
+      font: 'draw',
+      textAlign: 'start',
+      autoSize: true,
+      scale: 1,
+      richText: toRichText('')
+    }
+  }
+
+  getMinDimensions(shape) {
+    return textSizeCache.get(this.editor, shape.id)
+  }
+
+  getFontFaces() {
+    return []
+  }
+
+  component(shape) {
+    const {
+      id,
+      props: { richText, scale, textAlign }
+    } = shape
+    const { width, height } = this.getMinDimensions(shape)
+    const isSelected = shape.id === this.editor.getOnlySelectedShapeId()
+    const colorMode = useColorMode()
+    const dv = getDisplayValues(this, shape, colorMode)
+    const handleKeyDown = useTextShapeKeydownHandler(id)
+
+    return (
+      <RichTextLabel
+        shapeId={id}
+        classNamePrefix="tl-text-shape"
+        type="text"
+        fontFamily={dv.fontFamily}
+        fontSize={dv.fontSize}
+        lineHeight={dv.lineHeight}
+        textAlign={textAlign === 'middle' ? 'center' : textAlign}
+        verticalAlign="middle"
+        richText={richText}
+        labelColor={dv.color}
+        isSelected={isSelected}
+        textWidth={width}
+        textHeight={height}
+        showTextOutline={this.options.showTextOutline}
+        style={getTextRenderStyle(dv, scale)}
+        wrap
+        onKeyDown={handleKeyDown}
+      />
+    )
+  }
+
+  toSvg(shape, ctx) {
+    const bounds = this.editor.getShapeGeometry(shape).bounds
+    const width = bounds.width / (shape.props.scale ?? 1)
+    const height = bounds.height / (shape.props.scale ?? 1)
+    const dv = getDisplayValues(this, shape, ctx.colorMode)
+    const exportBounds = new Box(0, 0, width, height)
+
+    return (
+      <CowartRichTextSvg
+        fontSize={dv.fontSize}
+        fontFamily={dv.fontFamily}
+        lineHeight={dv.lineHeight}
+        textAlign={shape.props.textAlign === 'middle' ? 'center' : shape.props.textAlign}
+        verticalAlign="middle"
+        richText={shape.props.richText}
+        labelColor={dv.color}
+        bounds={exportBounds}
+        padding={0}
+        fontWeight={dv.fontWeight}
+        fontStyle={dv.fontStyle}
+        letterSpacing={dv.letterSpacing}
+        textDecoration={dv.textDecoration}
+        showTextOutline={this.options.showTextOutline}
+      />
+    )
+  }
+
+  onBeforeUpdate(prev, next) {
+    if (!next.props.autoSize) return
+
+    const styleDidChange =
+      prev.props.size !== next.props.size ||
+      prev.props.textAlign !== next.props.textAlign ||
+      prev.props.font !== next.props.font ||
+      prev.meta?.cowartTextFontFamily !== next.meta?.cowartTextFontFamily ||
+      prev.meta?.cowartTextFontSize !== next.meta?.cowartTextFontSize ||
+      (prev.props.scale !== 1 && next.props.scale === 1)
+
+    const textDidChange = !isEqual(prev.props.richText, next.props.richText)
+    if (!styleDidChange && !textDidChange) return
+
+    return super.onBeforeUpdate(prev, next)
+  }
+}
+
+export class CowartNoteShapeUtil extends NoteShapeUtil {
+  options = {
+    ...this.options,
+    getDefaultDisplayValues: (_editor, shape, theme, colorMode) => {
+      const { color, size, align, verticalAlign } = shape.props
+      const colors = theme.colors[colorMode]
+      const fontSize = getCowartFontSize(shape)
+      return {
+        noteWidth: 200,
+        noteHeight: 200,
+        noteBackgroundColor: getColorValue(colors, color, 'noteFill'),
+        borderColor: colors.noteBorder,
+        borderWidth: 2,
+        labelColor: getTextColor(shape, theme, colorMode),
+        labelFontFamily: getCowartFontFamily(getCowartFontKey(shape), shape.props.font),
+        labelFontSize: fontSize,
+        labelLineHeight: theme.lineHeight,
+        labelFontWeight: TEXT_PROPS.fontWeight,
+        labelFontVariant: TEXT_PROPS.fontVariant,
+        labelFontStyle: TEXT_PROPS.fontStyle,
+        labelPadding: 16,
+        labelHorizontalAlign: noteHorizontalAligns[align],
+        labelVerticalAlign: noteVerticalAligns[verticalAlign]
+      }
+    }
+  }
+
+  getDefaultProps() {
+    return {
+      color: 'black',
+      richText: toRichText(''),
+      size: 'm',
+      font: 'draw',
+      align: 'middle',
+      verticalAlign: 'middle',
+      labelColor: 'black',
+      growY: 0,
+      fontSizeAdjustment: 1,
+      url: '',
+      scale: 1,
+      textFirstEditedBy: null
+    }
+  }
+
+  getFontFaces() {
+    return []
+  }
+
+  component(shape) {
+    const { id, type, props } = shape
+    const { scale, richText, fontSizeAdjustment } = props
+    const colorMode = useColorMode()
+    const dv = getDisplayValues(this, shape, colorMode)
+    const isSelected = shape.id === this.editor.getOnlySelectedShapeId()
+    const noteHeight = getNoteHeight(shape, dv.noteHeight)
+    const handleKeyDown = useTextShapeKeydownHandler(id)
+
+    return (
+      <div
+        id={id}
+        className="tl-note__container"
+        style={{
+          width: dv.noteWidth * scale,
+          height: noteHeight,
+          backgroundColor: dv.noteBackgroundColor
+        }}
+      >
+        <RichTextLabel
+          shapeId={id}
+          type={type}
+          fontFamily={dv.labelFontFamily}
+          fontSize={(fontSizeAdjustment ?? 1) * dv.labelFontSize}
+          lineHeight={dv.labelLineHeight}
+          textAlign={dv.labelHorizontalAlign}
+          verticalAlign={dv.labelVerticalAlign}
+          richText={richText}
+          isSelected={isSelected}
+          labelColor={dv.labelColor}
+          wrap
+          padding={dv.labelPadding}
+          hasCustomTabBehavior
+          showTextOutline={false}
+          onKeyDown={handleKeyDown}
+          style={
+            scale !== 1
+              ? {
+                  ...getTextRenderStyle(dv, scale),
+                  width: dv.noteWidth,
+                  height: dv.noteHeight + shape.props.growY
+                }
+              : getTextRenderStyle(dv)
+          }
+        />
+      </div>
+    )
+  }
+
+  toSvg(shape, ctx) {
+    const dv = getDisplayValues(this, shape, ctx.colorMode)
+    const bounds = new Box(0, 0, dv.noteWidth, dv.noteHeight + shape.props.growY)
+
+    return (
+      <>
+        <rect rx={1} width={dv.noteWidth} height={bounds.h} fill={dv.noteBackgroundColor} />
+        <CowartRichTextSvg
+          fontSize={(shape.props.fontSizeAdjustment ?? 1) * dv.labelFontSize}
+          fontFamily={dv.labelFontFamily}
+          lineHeight={dv.labelLineHeight}
+          textAlign={dv.labelHorizontalAlign}
+          verticalAlign={dv.labelVerticalAlign}
+          richText={shape.props.richText}
+          labelColor={dv.labelColor}
+          bounds={bounds}
+          padding={dv.labelPadding}
+          fontWeight={dv.labelFontWeight}
+          fontStyle={dv.labelFontStyle}
+          letterSpacing={dv.letterSpacing}
+          textDecoration={dv.textDecoration}
+          showTextOutline={false}
+        />
+      </>
+    )
+  }
+
+  onBeforeUpdate(prev, next) {
+    const metaChanged =
+      prev.meta?.cowartTextFontFamily !== next.meta?.cowartTextFontFamily ||
+      prev.meta?.cowartTextFontSize !== next.meta?.cowartTextFontSize
+
+    if (!metaChanged) {
+      return super.onBeforeUpdate(prev, next)
+    }
+
+    const forcedPrev =
+      prev.props.font === next.props.font && prev.props.size === next.props.size
+        ? {
+            ...prev,
+            props: {
+              ...prev.props,
+              font: '__cowart_force__'
+            }
+          }
+        : prev
+
+    const baseNext = super.onBeforeUpdate(forcedPrev, next) ?? next
+
+    return {
+      ...baseNext,
+      props: {
+        ...baseNext.props,
+        fontSizeAdjustment: 1
+      }
+    }
+  }
+}

--- a/src/components/cowartTextStyles.js
+++ b/src/components/cowartTextStyles.js
@@ -1,0 +1,117 @@
+export const COWART_TEXT_FONT_OPTIONS = [
+  {
+    value: 'draw',
+    label: '手绘',
+    fontFamily: 'var(--tl-font-draw)',
+    baseFont: 'draw'
+  },
+  {
+    value: 'sans',
+    label: '无衬线',
+    fontFamily: 'var(--tl-font-sans)',
+    baseFont: 'sans'
+  },
+  {
+    value: 'serif',
+    label: '衬线',
+    fontFamily: 'var(--tl-font-serif)',
+    baseFont: 'serif'
+  },
+  {
+    value: 'mono',
+    label: '等宽',
+    fontFamily: 'var(--tl-font-mono)',
+    baseFont: 'mono'
+  },
+  {
+    value: 'yahei',
+    label: '微软雅黑',
+    fontFamily: '"Microsoft YaHei", "PingFang SC", "Hiragino Sans GB", sans-serif',
+    baseFont: 'sans'
+  },
+  {
+    value: 'pingfang',
+    label: '苹方',
+    fontFamily: '"PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif',
+    baseFont: 'sans'
+  },
+  {
+    value: 'heiti',
+    label: '黑体',
+    fontFamily: '"SimHei", "Microsoft YaHei", sans-serif',
+    baseFont: 'sans'
+  },
+  {
+    value: 'songti',
+    label: '宋体',
+    fontFamily: '"SimSun", "Songti SC", "STSong", serif',
+    baseFont: 'serif'
+  },
+]
+
+const TEXT_FONT_SIZE_MAP = {
+  s: 18,
+  m: 24,
+  l: 36,
+  xl: 44
+}
+
+const NOTE_FONT_SIZE_MAP = {
+  s: 18,
+  m: 22,
+  l: 26,
+  xl: 32
+}
+
+export function getCowartFontOption(value) {
+  return COWART_TEXT_FONT_OPTIONS.find((option) => option.value === value) ?? COWART_TEXT_FONT_OPTIONS[0]
+}
+
+export function getCowartFontFamily(value, fallback = 'sans') {
+  return getCowartFontOption(value ?? fallback).fontFamily
+}
+
+export function getCowartBaseFont(value, fallback = 'sans') {
+  return getCowartFontOption(value ?? fallback).baseFont
+}
+
+export function getCowartDefaultFontSize(shape) {
+  const size = shape?.props?.size
+  const map = shape?.type === 'note' ? NOTE_FONT_SIZE_MAP : TEXT_FONT_SIZE_MAP
+  return map[size] ?? map.m
+}
+
+export function getCowartFontSize(shape) {
+  const raw = Number(shape?.meta?.cowartTextFontSize)
+  if (Number.isFinite(raw) && raw > 0) {
+    return Math.min(Math.max(Math.round(raw), 8), 240)
+  }
+
+  return getCowartDefaultFontSize(shape)
+}
+
+export function getCowartFontKey(shape) {
+  const metaValue = shape?.meta?.cowartTextFontFamily
+  if (typeof metaValue === 'string') {
+    return getCowartFontOption(metaValue).value
+  }
+
+  return getCowartFontOption(shape?.props?.font ?? 'sans').value
+}
+
+export function getCowartNearestSizeStyle(shapeType, fontSize) {
+  const map = shapeType === 'note' ? NOTE_FONT_SIZE_MAP : TEXT_FONT_SIZE_MAP
+  const entries = Object.entries(map)
+  let nearest = entries[0]?.[0] ?? 'm'
+  let nearestDistance = Number.POSITIVE_INFINITY
+
+  for (const [size, value] of entries) {
+    const distance = Math.abs(Number(fontSize) - value)
+    if (distance < nearestDistance) {
+      nearest = size
+      nearestDistance = distance
+    }
+  }
+
+  return nearest
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -326,6 +326,10 @@ body {
 }
 
 .cowart-ai-aspect-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
 
 .cowart-inspector-header p {
   margin: 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,7 +12,7 @@ body,
 
 body {
   overflow: hidden;
-  background: #f7f5ef;
+  background: var(--cowart-canvas-background, #f7f5ef);
   color: #1f2430;
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
@@ -24,6 +24,7 @@ body {
   inset: 0;
   min-width: 0;
   min-height: 0;
+  --tl-color-background: var(--cowart-canvas-background, #f7f5ef);
 }
 
 .cowart-skipped-records {
@@ -178,6 +179,79 @@ body {
   line-height: 1.2;
 }
 
+.cowart-inspector {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 350;
+  color: #161616;
+  font-size: 13px;
+  pointer-events: none;
+}
+
+.cowart-inspector-toggle,
+.cowart-inspector-close,
+.cowart-settings-reset,
+.cowart-color-option,
+.cowart-preset-button,
+.cowart-transform-icon-button {
+  border: 1px solid #e6e6e6;
+  background: #ffffff;
+  color: #161616;
+  font: inherit;
+}
+
+.cowart-inspector-toggle {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(16, 16, 16, 0.08);
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.cowart-inspector-toggle span {
+  transform: translateY(-1px);
+}
+
+.cowart-inspector-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  width: min(340px, calc(100vw - 20px));
+  height: 100%;
+  border-left: 1px solid #ededed;
+  background: #ffffff;
+  box-shadow: -12px 0 32px rgba(15, 15, 15, 0.05);
+  pointer-events: auto;
+}
+
+.cowart-inspector-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px 12px;
+  border-bottom: 1px solid #efefef;
+}
+
+.cowart-inspector-header-copy {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+  margin-right: auto;
+}
+
+.cowart-inspector-header h2 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
 .cowart-ai-size-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 24px minmax(0, 1fr);
@@ -252,6 +326,504 @@ body {
 }
 
 .cowart-ai-aspect-grid {
+
+.cowart-inspector-header p {
+  margin: 0;
+  color: #8b8b8b;
+  font-size: 11px;
+  line-height: 1.2;
+}
+
+.cowart-save-badge {
+  display: inline-flex;
+  min-height: 24px;
+  padding: 0 8px;
+  align-items: center;
+  border: 1px solid #ececec;
+  border-radius: 999px;
+  background: #f6f6f6;
+  color: #6f6f6f;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.cowart-inspector-close {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.cowart-inspector-body {
+  display: grid;
+  align-content: start;
+  min-height: 0;
+  overflow: auto;
+}
+
+.cowart-inspector-tabs {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  padding: 8px 16px 10px;
+  border-bottom: 1px solid #efefef;
+  background: #ffffff;
+}
+
+.cowart-inspector-tab {
+  min-height: 36px;
+  padding: 0 10px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  color: #6f6f6f;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease;
+}
+
+.cowart-inspector-tab[data-active="true"] {
+  border-color: #161616;
+  background: transparent;
+  color: #111111;
+}
+
+.cowart-inspector-section {
+  display: grid;
+  gap: 12px;
+  padding: 16px 16px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.cowart-inspector-section-compact {
+  gap: 12px;
+}
+
+.cowart-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cowart-section-header h3 {
+  margin: 0;
+  color: #111111;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.cowart-section-empty {
+  margin: 0;
+  color: #8a8a8a;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.cowart-section-note {
+  margin: 0;
+  color: #8a8a8a;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.cowart-selection-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.cowart-selection-meta span {
+  color: #646464;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.cowart-selection-meta strong {
+  color: #111111;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.4;
+  word-break: break-all;
+}
+
+.cowart-selection-chip {
+  display: inline-flex;
+  min-height: 24px;
+  padding: 0 10px;
+  align-items: center;
+  border: 1px solid #ececec;
+  border-radius: 999px;
+  background: #f4f4f4;
+}
+
+.cowart-setting-row,
+.cowart-setting-switch,
+.cowart-setting-range,
+.cowart-setting-grid label,
+.cowart-setting-stack {
+  display: grid;
+  gap: 6px;
+}
+
+.cowart-setting-row,
+.cowart-setting-switch {
+  grid-template-columns: 1fr auto;
+  align-items: center;
+}
+
+.cowart-setting-row-surface {
+  min-height: 42px;
+  padding: 0 12px;
+  border: 1px solid #eeeeee;
+  border-radius: 12px;
+  background: #fafafa;
+}
+
+.cowart-setting-row span,
+.cowart-setting-switch span,
+.cowart-setting-range span,
+.cowart-setting-grid span,
+.cowart-setting-stack span,
+.cowart-color-field legend {
+  color: #505050;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.cowart-setting-range span {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cowart-setting-range strong {
+  color: #111111;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.cowart-setting-range input {
+  width: 100%;
+  accent-color: #2577ff;
+}
+
+.cowart-setting-row input[type="color"] {
+  width: 44px;
+  height: 30px;
+  padding: 2px;
+  border: 1px solid #e8e8e8;
+  border-radius: 8px;
+  background: #f2f2f2;
+}
+
+.cowart-setting-switch input {
+  width: 36px;
+  height: 20px;
+  accent-color: #2577ff;
+}
+
+.cowart-setting-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.cowart-setting-grid-surface {
+  padding: 8px;
+  border: 1px solid #eeeeee;
+  border-radius: 12px;
+  background: #fafafa;
+}
+
+.cowart-setting-grid input {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid #e9e9e9;
+  border-radius: 10px;
+  background: #f2f2f2;
+  color: #111111;
+  font: inherit;
+}
+
+.cowart-setting-stack input {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid #e9e9e9;
+  border-radius: 10px;
+  background: #f2f2f2;
+  color: #111111;
+  font: inherit;
+}
+
+.cowart-setting-stack select {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid #e9e9e9;
+  border-radius: 10px;
+  background: #f2f2f2;
+  color: #111111;
+  font: inherit;
+}
+
+.cowart-style-stack {
+  display: grid;
+  gap: 12px;
+}
+
+.cowart-subsection {
+  display: grid;
+  gap: 12px;
+}
+
+.cowart-property-group {
+  display: grid;
+  gap: 12px;
+  padding-top: 2px;
+}
+
+.cowart-property-group-geometry,
+.cowart-property-group-layer,
+.cowart-property-group-styles,
+.cowart-property-group-text,
+.cowart-property-group-canvas {
+  gap: 10px;
+}
+
+.cowart-property-group + .cowart-property-group {
+  padding-top: 16px;
+  border-top: 1px solid #f0f0f0;
+}
+
+.cowart-property-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cowart-property-group-header h4 {
+  margin: 0;
+  color: #121212;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.cowart-property-row {
+  display: grid;
+  gap: 10px;
+}
+
+.cowart-property-row-compact {
+  gap: 8px;
+}
+
+.cowart-property-label {
+  color: #232323;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.cowart-inline-control-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.cowart-inline-control-row-single {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.cowart-compact-select {
+  display: grid;
+  gap: 6px;
+}
+
+.cowart-compact-select span {
+  color: #7d7d7d;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.cowart-compact-select-surface {
+  padding: 8px;
+  border: 1px solid #eeeeee;
+  border-radius: 12px;
+  background: #fafafa;
+}
+
+.cowart-compact-select select {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid #e9e9e9;
+  border-radius: 10px;
+  background: #f2f2f2;
+  color: #111111;
+  font: inherit;
+}
+
+.cowart-compact-select input {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid #e9e9e9;
+  border-radius: 10px;
+  background: #f2f2f2;
+  color: #111111;
+  font: inherit;
+}
+
+.cowart-compact-select-surface select,
+.cowart-compact-select-surface input {
+  background: #f2f2f2;
+}
+
+.cowart-input-with-suffix {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid #e9e9e9;
+  border-radius: 10px;
+  background: #f2f2f2;
+}
+
+.cowart-input-with-suffix input {
+  height: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.cowart-input-with-suffix input:focus {
+  outline: none;
+}
+
+.cowart-input-with-suffix em {
+  color: #6b6b6b;
+  font-style: normal;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.cowart-setting-switch-surface {
+  min-height: 40px;
+  padding: 0 12px;
+  border: 1px solid #eeeeee;
+  border-radius: 12px;
+  background: #fafafa;
+}
+
+.cowart-object-transform {
+  display: grid;
+  gap: 12px;
+}
+
+.cowart-object-transform-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.cowart-transform-field {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-height: 30px;
+  padding: 0 10px;
+  border-radius: 10px;
+  border: 1px solid #ececec;
+  background: #f2f2f2;
+}
+
+.cowart-transform-field span {
+  color: #7a7a7a;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.cowart-transform-field input {
+  width: 100%;
+  min-width: 0;
+  height: 30px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #111111;
+  font: inherit;
+  font-size: 14px;
+}
+
+.cowart-transform-field input:disabled {
+  color: #a7a7a7;
+  cursor: not-allowed;
+}
+
+.cowart-transform-field:has(input:disabled) {
+  background: #f8f8f8;
+}
+
+.cowart-transform-field input:focus {
+  outline: none;
+}
+
+.cowart-transform-icon-button {
+  display: grid;
+  min-height: 30px;
+  place-items: center;
+  border-radius: 10px;
+  background: #f2f2f2;
+  color: #555555;
+  font: inherit;
+  cursor: pointer;
+}
+
+.cowart-transform-icon-button:disabled {
+  color: #b1b1b1;
+  cursor: not-allowed;
+}
+
+.cowart-transform-icon-button[aria-pressed="true"] {
+  border-color: #111111;
+  color: #111111;
+}
+
+.cowart-transform-note {
+  grid-column: 1 / -1;
+}
+
+.cowart-section-subtitle {
+  color: #111111;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.cowart-preset-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 8px;
@@ -293,4 +865,190 @@ body {
   display: block;
   border: 2px solid var(--tl-color-text);
   border-radius: 4px;
+}
+
+.cowart-preset-button {
+  min-height: 34px;
+  padding: 8px 8px;
+  border-radius: 10px;
+  font: inherit;
+  font-weight: 600;
+  text-align: center;
+  cursor: pointer;
+}
+
+.cowart-preset-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.cowart-color-field {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.cowart-color-field-compact {
+  gap: 6px;
+}
+
+.cowart-color-input-row {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  gap: 8px;
+}
+
+.cowart-color-native-input {
+  width: 44px;
+  height: 34px;
+  padding: 2px;
+  border: 1px solid #e9e9e9;
+  border-radius: 10px;
+  background: #f2f2f2;
+  cursor: pointer;
+}
+
+.cowart-color-text-input {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid #e9e9e9;
+  border-radius: 10px;
+  background: #f2f2f2;
+  color: #111111;
+  font: inherit;
+}
+
+.cowart-color-text-input:focus {
+  outline: none;
+  border-color: #bdbdbd;
+}
+
+.cowart-color-options {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 6px;
+}
+
+.cowart-color-option {
+  display: grid;
+  aspect-ratio: 1;
+  min-width: 0;
+  padding: 2px;
+  place-items: center;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.cowart-color-option[aria-pressed="true"] {
+  border-color: #111111;
+  box-shadow: 0 0 0 1px #111111;
+}
+
+.cowart-color-option span {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 6px;
+}
+
+.cowart-settings-reset {
+  height: 34px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.cowart-settings-reset-surface {
+  border-color: #eeeeee;
+  background: #fafafa;
+}
+
+.cowart-primary-action {
+  height: 36px;
+  border: 1px solid #1f1f1f;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #111111;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.cowart-primary-action:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.cowart-inline-control-row-text {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.cowart-text-control-stack {
+  display: grid;
+  gap: 8px;
+}
+
+.cowart-text-segment-grid {
+  display: grid;
+  gap: 8px;
+}
+
+.cowart-segmented-control {
+  display: grid;
+  gap: 6px;
+}
+
+.cowart-segmented-control > span {
+  color: #7d7d7d;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.cowart-segmented-control-track {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid #eeeeee;
+  border-radius: 12px;
+  background: #fafafa;
+}
+
+.cowart-segmented-control-button {
+  min-height: 30px;
+  padding: 0 8px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: #646464;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.cowart-segmented-control-button[data-active="true"] {
+  border-color: #dddddd;
+  background: #f0f0f0;
+  color: #111111;
+}
+
+@media (max-width: 640px) {
+  .cowart-inspector {
+    top: 10px;
+    right: 10px;
+  }
+
+  .cowart-inspector-panel {
+    width: min(300px, calc(100vw - 12px));
+  }
+
+  .cowart-preset-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { randomUUID } from 'node:crypto'
 import { createReadStream } from 'node:fs'
-import { copyFile, mkdir, readFile, readdir, rename, stat, writeFile } from 'node:fs/promises'
+import { copyFile, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, dirname, extname, join, relative, resolve, sep } from 'node:path'
 
 const projectDir = resolve(process.env.COWART_PROJECT_DIR ?? process.cwd())
@@ -10,6 +10,7 @@ const canvasDir = resolve(process.env.COWART_CANVAS_DIR ?? join(projectDir, 'can
 const canvasFile = join(canvasDir, 'cowart-canvas.json')
 const selectionFile = join(canvasDir, 'cowart-selection.json')
 const viewStateFile = join(canvasDir, 'cowart-view-state.json')
+const settingsFile = join(canvasDir, 'cowart-settings.json')
 const canvasPagesDir = join(canvasDir, 'pages')
 const canvasAssetsDir = join(canvasDir, 'assets')
 const pagesManifestFile = join(canvasPagesDir, 'manifest.json')
@@ -20,6 +21,28 @@ const pageAssetsRoute = '/page-assets/'
 const canvasEventClients = new Set()
 let canvasEventVersion = 0
 let canvasSnapshotSanitizerPromise = null
+const defaultCanvasSettings = {
+  version: 1,
+  backgroundColor: '#f7f5ef',
+  showGrid: false,
+  aiImageHolderWidth: 320,
+  aiImageHolderHeight: 220,
+  annotationColor: 'red'
+}
+const allowedAnnotationColors = new Set([
+  'black',
+  'grey',
+  'light-violet',
+  'violet',
+  'blue',
+  'light-blue',
+  'yellow',
+  'orange',
+  'green',
+  'light-green',
+  'light-red',
+  'red'
+])
 
 const mimeTypes = new Map([
   ['.apng', 'image/apng'],
@@ -112,6 +135,33 @@ function isViewState(value) {
     isFiniteNumber(value.camera.y) &&
     isFiniteNumber(value.camera.z)
   )
+}
+
+function normalizeCanvasSettings(value) {
+  const settings = value && typeof value === 'object' ? value : {}
+  const backgroundColor =
+    typeof settings.backgroundColor === 'string' && /^#[0-9a-fA-F]{6}$/.test(settings.backgroundColor)
+      ? settings.backgroundColor
+      : defaultCanvasSettings.backgroundColor
+  const aiImageHolderWidth = isFiniteNumber(settings.aiImageHolderWidth)
+    ? Math.min(Math.max(Math.round(settings.aiImageHolderWidth), 80), 2400)
+    : defaultCanvasSettings.aiImageHolderWidth
+  const aiImageHolderHeight = isFiniteNumber(settings.aiImageHolderHeight)
+    ? Math.min(Math.max(Math.round(settings.aiImageHolderHeight), 80), 2400)
+    : defaultCanvasSettings.aiImageHolderHeight
+  const annotationColor = allowedAnnotationColors.has(settings.annotationColor)
+    ? settings.annotationColor
+    : defaultCanvasSettings.annotationColor
+
+  return {
+    ...defaultCanvasSettings,
+    backgroundColor,
+    showGrid: Boolean(settings.showGrid),
+    aiImageHolderWidth,
+    aiImageHolderHeight,
+    annotationColor,
+    updatedAt: typeof settings.updatedAt === 'string' ? settings.updatedAt : null
+  }
 }
 
 function isSafeChildPath(parent, child) {
@@ -386,12 +436,32 @@ async function writeJsonAtomic(filePath, payload) {
   await rename(tempFile, filePath)
 }
 
+async function removeStalePageDirs(currentPageIds) {
+  let entries
+  try {
+    entries = await readdir(canvasPagesDir, { withFileTypes: true })
+  } catch (error) {
+    if (error.code === 'ENOENT') return
+    throw error
+  }
+
+  const currentDirNames = new Set([...currentPageIds].map(pageDirName))
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory() && !currentDirNames.has(entry.name))
+      .map((entry) => rm(join(canvasPagesDir, entry.name), { recursive: true, force: true }))
+  )
+}
+
 async function saveCanvasSnapshot(snapshot) {
   const pages = getPageRecords(snapshot)
   if (pages.length === 0) {
     await writeJsonAtomic(canvasFile, snapshot)
     return { storage: 'legacy-single-file', paths: [canvasFile] }
   }
+
+  const currentPageIds = new Set(pages.map((page) => page.id))
+  await removeStalePageDirs(currentPageIds)
 
   const paths = []
   for (const page of pages) {
@@ -562,6 +632,47 @@ function canvasStoragePlugin() {
 
             await writeJsonAtomic(viewStateFile, viewState)
             sendJson(res, 200, { ok: true, path: viewStateFile })
+            return
+          }
+
+          res.statusCode = 405
+          res.setHeader('allow', 'GET, PUT')
+          res.end()
+        } catch (error) {
+          sendJson(res, 500, { error: error.message })
+        }
+      })
+
+      server.middlewares.use('/api/settings', async (req, res) => {
+        try {
+          if (req.method === 'GET') {
+            try {
+              sendJson(res, 200, {
+                settings: normalizeCanvasSettings(await readJsonFile(settingsFile)),
+                path: settingsFile
+              })
+            } catch (error) {
+              if (error.code === 'ENOENT') {
+                sendJson(res, 200, {
+                  settings: normalizeCanvasSettings(null),
+                  path: settingsFile
+                })
+                return
+              }
+              throw error
+            }
+            return
+          }
+
+          if (req.method === 'PUT') {
+            const body = await readRequestBody(req)
+            const settings = normalizeCanvasSettings(JSON.parse(body))
+            const payload = {
+              ...settings,
+              updatedAt: new Date().toISOString()
+            }
+            await writeJsonAtomic(settingsFile, payload)
+            sendJson(res, 200, { ok: true, settings: payload, path: settingsFile })
             return
           }
 


### PR DESCRIPTION
**本次提交新增右侧属性面板，支持对画布设置和选中对象属性进行查看与编辑：**

1. 画布设置支持调整并持久化保存背景色、网格显示、AI 图片占位框默认尺寸和标注默认颜色等配置，支持图片导出。
2. 对象属性支持编辑位置、尺寸、旋转、不透明度、填充、描边、文字样式，以及图片圆角、边框、阴影、模糊等外观参数。
3. 同时新增 /api/settings 接口，用于读取和保存画布设置。
4. 补充选中图形信息展示，并对画布快照中的颜色数据做兼容与规范化处理，提升编辑体验和数据稳定性。

<img width="1454" height="986" alt="Snipaste_2026-06-25_11-10-05" src="https://github.com/user-attachments/assets/92a93fe6-5afe-488c-82d5-617581f78ba3" />
<img width="1445" height="989" alt="Snipaste_2026-06-25_11-10-47" src="https://github.com/user-attachments/assets/fc2d92f5-d984-46af-8e8f-864e053104f7" />
<img width="1457" height="986" alt="Snipaste_2026-06-25_11-11-13" src="https://github.com/user-attachments/assets/672748dc-215d-49fe-9352-4096a21b8b5c" />
<img width="315" height="362" alt="Snipaste_2026-06-25_11-13-45" src="https://github.com/user-attachments/assets/607f7487-7edb-4f30-8d4c-f3c7b58e8423" />

