### PR TITLE
Fix Windows shell script line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
## Summary
- Add `.gitattributes` to force shell scripts to check out with LF line endings.

## Why
On Windows, Git can check out `.sh` files with CRLF when `core.autocrlf` is enabled. Running those scripts with bash can then fail before startup with errors like `set: pipefail\r: invalid option name`.

## Validation
- Ran `bash -n ./scripts/start-canvas.sh`
- Ran `bash -n ./scripts/start-mcp.sh`
- Verified both scripts have LF line endings locally
