### PR TITLE
[codex] Delete stale Cowart page dirs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "node --test --test-force-exit",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/test/canvas-storage.test.js
+++ b/test/canvas-storage.test.js
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict'
+import { access, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test } from 'node:test'
+import { createServer } from 'vite'
+import { createTLStore, PageRecordType } from 'tldraw'
+
+const rootDir = dirname(fileURLToPath(new URL('../vite.config.js', import.meta.url)))
+
+function page(id, name, index) {
+  return PageRecordType.create({
+    id: PageRecordType.createId(id),
+    name,
+    index
+  })
+}
+
+function snapshotWithPages(...pages) {
+  return {
+    schema: createTLStore().schema.serialize(),
+    store: Object.fromEntries(pages.map((record) => [record.id, record]))
+  }
+}
+
+function pageFilePath(canvasDir, pageId) {
+  const pageDirName = encodeURIComponent(pageId.replace('page:', ''))
+  return join(canvasDir, 'pages', pageDirName, 'cowart-canvas.json')
+}
+
+async function pathExists(path) {
+  try {
+    await access(path)
+    return true
+  } catch (error) {
+    if (error.code === 'ENOENT') return false
+    throw error
+  }
+}
+
+async function putCanvas(baseUrl, snapshot) {
+  const response = await fetch(`${baseUrl}/api/canvas`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(snapshot)
+  })
+  const body = await response.json()
+  assert.equal(response.status, 200, JSON.stringify(body))
+  return body
+}
+
+test('removes page files that are not in the latest canvas snapshot', async () => {
+  const canvasDir = await mkdtemp(join(tmpdir(), 'cowart-canvas-'))
+  process.env.COWART_CANVAS_DIR = canvasDir
+
+  const server = await createServer({
+    configFile: join(rootDir, 'vite.config.js'),
+    logLevel: 'silent',
+    server: {
+      host: '127.0.0.1',
+      port: 0
+    }
+  })
+
+  await server.listen()
+
+  try {
+    const { port } = server.httpServer.address()
+    const baseUrl = `http://127.0.0.1:${port}`
+    const firstPage = page('first', 'First', 'a1')
+    const deletedPage = page('deleted', 'Deleted', 'a2')
+
+    await putCanvas(baseUrl, snapshotWithPages(firstPage, deletedPage))
+    assert.equal(await pathExists(pageFilePath(canvasDir, deletedPage.id)), true)
+
+    await putCanvas(baseUrl, snapshotWithPages(firstPage))
+
+    assert.equal(
+      await pathExists(pageFilePath(canvasDir, deletedPage.id)),
+      false,
+      'stale per-page snapshot should be removed'
+    )
+
+    const response = await fetch(`${baseUrl}/api/canvas`)
+    const body = await response.json()
+    assert.equal(response.status, 200, JSON.stringify(body))
+    assert.deepEqual(
+      Object.keys(body.snapshot.store).sort(),
+      [firstPage.id],
+      'stale page records should not be merged into the loaded snapshot'
+    )
+  } finally {
+    server.httpServer.closeAllConnections?.()
+    await server.close()
+    delete process.env.COWART_CANVAS_DIR
+    await rm(canvasDir, { recursive: true, force: true })
+  }
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { randomUUID } from 'node:crypto'
 import { createReadStream } from 'node:fs'
-import { copyFile, mkdir, readFile, readdir, rename, stat, writeFile } from 'node:fs/promises'
+import { copyFile, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, dirname, extname, join, relative, resolve, sep } from 'node:path'
 
 const projectDir = resolve(process.env.COWART_PROJECT_DIR ?? process.cwd())
@@ -386,8 +386,28 @@ async function writeJsonAtomic(filePath, payload) {
   await rename(tempFile, filePath)
 }
 
+async function removeStalePageDirs(currentPageIds) {
+  let entries
+  try {
+    entries = await readdir(canvasPagesDir, { withFileTypes: true })
+  } catch (error) {
+    if (error.code === 'ENOENT') return
+    throw error
+  }
+
+  const currentDirNames = new Set([...currentPageIds].map(pageDirName))
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory() && !currentDirNames.has(entry.name))
+      .map((entry) => rm(join(canvasPagesDir, entry.name), { recursive: true, force: true }))
+  )
+}
+
 async function saveCanvasSnapshot(snapshot) {
   const pages = getPageRecords(snapshot)
+  const currentPageIds = new Set(pages.map((page) => page.id))
+  await removeStalePageDirs(currentPageIds)
+
   if (pages.length === 0) {
     await writeJsonAtomic(canvasFile, snapshot)
     return { storage: 'legacy-single-file', paths: [canvasFile] }


### PR DESCRIPTION
## Summary

- Delete stale per-page canvas directories before persisting the latest canvas snapshot.
- Add a regression test that saves two pages, saves a one-page snapshot, and verifies the deleted page file is gone and not merged on load.

## Root cause

The server rewrote `canvas/pages/manifest.json` after a page was deleted, but old `canvas/pages/<page-id>/cowart-canvas.json` files remained on disk. `loadCanvasSnapshot()` scans every page directory, so stale page files were merged back into the canvas.

## Validation

- `npm test`
- Vite build API completed successfully via `build({ configFile: "vite.config.js" })`
