### PR TITLE
feat: 支持阿里生图模型-图片生成模型的选择

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -151,6 +151,30 @@ Useful environment variables:
 - `COWART_PROJECT_DIR`: the user project directory that owns the canvas data.
 - `COWART_CANVAS_DIR`: canvas data directory, default `$COWART_PROJECT_DIR/canvas`.
 
+### Optional: Alibaba DashScope / Qwen / Wan Image Models
+
+Cowart still uses the built-in OpenAI image generation flow by default. The top-left main menu includes `模型选择`; it defaults to `OpenAI`, and users can switch it to `阿里千问`. Cowart saves that preference to the current project's `canvas/cowart-model-preferences.json`. DashScope is used only when the user selects Alibaba in the UI, explicitly asks for an Alibaba model, or sets the provider environment variable below, so the existing OpenAI workflow is unaffected.
+
+Users can also fill the Alibaba config in the UI: open the top-left main menu, choose `模型选择` → `配置阿里千问`, then enter `DASHSCOPE_API_KEY`, `DASHSCOPE_BASE_URL`, and the model name. The API key is saved in the machine-local Cowart config directory, not in the current project's `canvas/` folder.
+
+```bash
+export COWART_IMAGE_PROVIDER=dashscope
+export DASHSCOPE_API_KEY=sk-...
+export DASHSCOPE_BASE_URL=https://<workspace-id>.cn-beijing.maas.aliyuncs.com/api/v1
+export COWART_DASHSCOPE_IMAGE_MODEL=wan2.7-image-pro
+```
+
+You can also generate a local image only when needed:
+
+```bash
+node scripts/generate-dashscope-image.mjs \
+  --prompt "A polished 3:4 product poster with Chinese title text" \
+  --width 512 \
+  --height 683
+```
+
+The script prints JSON containing `outputPath`. Use that local file path with Cowart's normal image insertion workflow. `wan2.7-image-pro` is an Alibaba Wan image model; to use a Qwen Image model, set `COWART_DASHSCOPE_IMAGE_MODEL` to the matching Qwen Image model name.
+
 ## Developer
 
 ZHONG XIN  

--- a/README.md
+++ b/README.md
@@ -151,6 +151,30 @@ npm run build
 - `COWART_PROJECT_DIR`：画布数据所属的用户项目目录。
 - `COWART_CANVAS_DIR`：画布数据目录，默认是 `$COWART_PROJECT_DIR/canvas`。
 
+### 可选：接入阿里 DashScope / 千问 / 万相图片模型
+
+Cowart 默认仍使用 Codex 内置的 OpenAI 图片生成能力。左上角主菜单里有 `模型选择`，默认是 `OpenAI`；用户可以切换到 `阿里千问`，Cowart 会把选择保存到当前项目的 `canvas/cowart-model-preferences.json`。只有当用户在页面选择阿里、显式要求使用阿里模型，或设置下面的 provider 环境变量时，才会走 DashScope，不会影响原来的 OpenAI 生成流程。
+
+也可以直接在前端填写阿里配置：打开左上角主菜单，选择 `模型选择` → `配置阿里千问`，填写 `DASHSCOPE_API_KEY`、`DASHSCOPE_BASE_URL` 和模型名。API Key 会保存到本机用户目录里的 Cowart 配置文件，不会写入当前项目的 `canvas/`。
+
+```bash
+export COWART_IMAGE_PROVIDER=dashscope
+export DASHSCOPE_API_KEY=sk-...
+export DASHSCOPE_BASE_URL=https://<workspace-id>.cn-beijing.maas.aliyuncs.com/api/v1
+export COWART_DASHSCOPE_IMAGE_MODEL=wan2.7-image-pro
+```
+
+也可以只在需要时手动生成一张本地图片：
+
+```bash
+node scripts/generate-dashscope-image.mjs \
+  --prompt "一张适合 3:4 画布的产品海报，干净高级，有中文标题" \
+  --width 512 \
+  --height 683
+```
+
+脚本会输出包含 `outputPath` 的 JSON。把这个本地图片路径交给 Cowart 插入流程即可。`wan2.7-image-pro` 属于阿里万相 Wan 图片模型；如果你要换成千问图片模型，可以把 `COWART_DASHSCOPE_IMAGE_MODEL` 改为对应的 Qwen Image 模型名。
+
 ## 开发者
 
 ZHONG XIN  

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -1,4 +1,5 @@
 import { copyFile, mkdir, readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
 import { basename, extname, join, relative, resolve, sep } from "node:path";
 import readline from "node:readline";
 import { generateKeyBetween } from "fractional-indexing";
@@ -7,6 +8,7 @@ const SERVER_NAME = "Cowart MCP";
 const SERVER_VERSION = "0.1.1";
 const TOOL_GET_SELECTION = "get_cowart_selection";
 const TOOL_INSERT_IMAGE = "insert_cowart_image";
+const TOOL_GET_MODEL_PREFERENCES = "get_cowart_model_preferences";
 const PAGE_ID_PREFIX = "page:";
 const PAGE_ASSETS_ROUTE = "/page-assets/";
 const CANVAS_FILE_NAME = "cowart-canvas.json";
@@ -62,6 +64,40 @@ function resolveSelectionFile(args = {}) {
 
 function resolveViewStateFile(args = {}) {
   return join(resolveCanvasDir(args), "cowart-view-state.json");
+}
+
+function resolveModelPreferencesFile(args = {}) {
+  return join(resolveCanvasDir(args), "cowart-model-preferences.json");
+}
+
+function defaultModelPreferences() {
+  return {
+    version: 1,
+    imageProvider: "openai",
+    imageModel: "openai",
+    updatedAt: null,
+  };
+}
+
+function resolveDashscopeConfigFile() {
+  const explicitConfig = nonEmptyString(process.env.COWART_DASHSCOPE_CONFIG);
+  if (explicitConfig) return pathResolve(explicitConfig);
+
+  const configDir =
+    nonEmptyString(process.env.COWART_CONFIG_DIR) ||
+    (nonEmptyString(process.env.APPDATA) ? join(process.env.APPDATA, "Cowart") : join(homedir(), ".cowart"));
+  return join(configDir, "dashscope-config.json");
+}
+
+function publicDashscopeConfig(config) {
+  const apiKey = typeof config?.apiKey === "string" ? config.apiKey : "";
+  return {
+    configured: apiKey.trim().length > 0,
+    baseUrl: typeof config?.baseUrl === "string" ? config.baseUrl : "",
+    model: typeof config?.model === "string" && config.model.trim() ? config.model : "wan2.7-image-pro",
+    apiKeyPreview: apiKey ? `${apiKey.slice(0, 6)}...${apiKey.slice(-4)}` : "",
+    updatedAt: config?.updatedAt ?? null,
+  };
 }
 
 function pageDirName(pageId) {
@@ -173,6 +209,25 @@ async function readViewState(args) {
     return payload?.viewState ?? payload;
   } catch (error) {
     if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function readModelPreferences(args) {
+  const modelPreferencesFile = resolveModelPreferencesFile(args);
+  const dashscopeConfigFile = resolveDashscopeConfigFile();
+  let dashscopeConfig = publicDashscopeConfig({});
+  try {
+    dashscopeConfig = publicDashscopeConfig(JSON.parse(await readFile(dashscopeConfigFile, "utf8")));
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+
+  try {
+    const preferences = JSON.parse(await readFile(modelPreferencesFile, "utf8"));
+    return { preferences: { ...defaultModelPreferences(), ...preferences }, modelPreferencesFile, dashscopeConfig, dashscopeConfigFile };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { preferences: defaultModelPreferences(), modelPreferencesFile, dashscopeConfig, dashscopeConfigFile };
     throw error;
   }
 }
@@ -510,6 +565,32 @@ function toolDefinitions() {
       },
     },
     {
+      name: TOOL_GET_MODEL_PREFERENCES,
+      title: "Get Cowart Model Preferences",
+      description:
+        "Return the Cowart image model preference selected in the canvas UI. Defaults to OpenAI when no preference file exists.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          projectDir: {
+            type: "string",
+            description: "Absolute Cowart project directory. The tool reads <projectDir>/canvas/cowart-model-preferences.json.",
+          },
+          canvasDir: {
+            type: "string",
+            description: "Absolute canvas directory. If provided, this takes precedence over projectDir.",
+          },
+        },
+        additionalProperties: false,
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    {
       name: TOOL_INSERT_IMAGE,
       title: "Insert Cowart Image",
       description:
@@ -580,6 +661,16 @@ async function handleToolCall(id, params) {
         },
       ],
       structuredContent: result,
+    });
+    return;
+  }
+
+  if (params?.name === TOOL_GET_MODEL_PREFERENCES) {
+    const { preferences, modelPreferencesFile, dashscopeConfig, dashscopeConfigFile } = await readModelPreferences(params.arguments ?? {});
+    const providerLabel = preferences.imageProvider === "dashscope" ? "DashScope / Alibaba" : "OpenAI";
+    sendResult(id, {
+      content: [{ type: "text", text: `Cowart image provider: ${providerLabel} (${preferences.imageModel || "default"}).` }],
+      structuredContent: { preferences, modelPreferencesFile, dashscopeConfig, dashscopeConfigFile },
     });
     return;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2363,9 +2363,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2378,9 +2375,6 @@
       "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2395,9 +2389,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2410,9 +2401,6 @@
       "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2427,9 +2415,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2442,9 +2427,6 @@
       "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2459,9 +2441,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2474,9 +2453,6 @@
       "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2491,9 +2467,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2506,9 +2479,6 @@
       "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2523,9 +2493,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2539,9 +2506,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2554,9 +2518,6 @@
       "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/scripts/generate-dashscope-image.mjs
+++ b/scripts/generate-dashscope-image.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, extname, join, resolve } from "node:path";
+
+const DEFAULT_MODEL = "wan2.7-image-pro";
+const DEFAULT_REGION = "cn-beijing";
+const DEFAULT_SIZE = "2K";
+
+function printUsage() {
+  console.error(`Usage:
+  node scripts/generate-dashscope-image.mjs --prompt "..." [--width 512 --height 683]
+  node scripts/generate-dashscope-image.mjs --prompt-file prompt.txt --size 2K --out-dir generated
+
+Environment:
+  DASHSCOPE_API_KEY              Required.
+  DASHSCOPE_BASE_URL             Preferred, e.g. https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/api/v1
+  DASHSCOPE_WORKSPACE_ID         Used when DASHSCOPE_BASE_URL is not set.
+  DASHSCOPE_REGION               Defaults to cn-beijing.
+  COWART_DASHSCOPE_IMAGE_MODEL   Defaults to wan2.7-image-pro.
+  COWART_DASHSCOPE_IMAGE_SIZE    Defaults to 2K when width/height are not provided.`);
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+async function readDashscopeConfig() {
+  const explicitConfig = nonEmptyString(process.env.COWART_DASHSCOPE_CONFIG);
+  const configDir =
+    nonEmptyString(process.env.COWART_CONFIG_DIR) ||
+    (nonEmptyString(process.env.APPDATA) ? join(process.env.APPDATA, "Cowart") : join(homedir(), ".cowart"));
+  const configPath = explicitConfig || join(configDir, "dashscope-config.json");
+
+  try {
+    return JSON.parse(await readFile(configPath, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") return {};
+    throw error;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function safeFileName(value, fallback = "dashscope-image.png") {
+  const raw = basename(String(value || fallback));
+  const ext = extname(raw) || ".png";
+  const base = raw
+    .slice(0, raw.length - extname(raw).length)
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `${base || "dashscope-image"}${ext}`;
+}
+
+function roundToMultiple(value, multiple) {
+  return Math.max(multiple, Math.round(value / multiple) * multiple);
+}
+
+function customSizeForDimensions(width, height, maxSide = 4096) {
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+
+  let nextWidth = width;
+  let nextHeight = height;
+  const minSide = Math.min(nextWidth, nextHeight);
+  if (minSide < 768) {
+    const scale = 768 / minSide;
+    nextWidth *= scale;
+    nextHeight *= scale;
+  }
+
+  const largestSide = Math.max(nextWidth, nextHeight);
+  if (largestSide > maxSide) {
+    const scale = maxSide / largestSide;
+    nextWidth *= scale;
+    nextHeight *= scale;
+  }
+
+  nextWidth = roundToMultiple(nextWidth, 16);
+  nextHeight = roundToMultiple(nextHeight, 16);
+
+  const ratio = Math.max(nextWidth, nextHeight) / Math.min(nextWidth, nextHeight);
+  if (ratio > 8) {
+    throw new Error(`DashScope image size ratio must be within 1:8 to 8:1, got ${nextWidth}*${nextHeight}.`);
+  }
+
+  return `${nextWidth}*${nextHeight}`;
+}
+
+function resolveBaseUrl(config = {}) {
+  const explicitBaseUrl = nonEmptyString(process.env.DASHSCOPE_BASE_URL) || nonEmptyString(config.baseUrl);
+  if (explicitBaseUrl) return explicitBaseUrl.replace(/\/+$/, "");
+
+  const workspaceId = nonEmptyString(process.env.DASHSCOPE_WORKSPACE_ID);
+  if (!workspaceId) {
+    throw new Error("Set DASHSCOPE_BASE_URL or DASHSCOPE_WORKSPACE_ID before using the DashScope image provider.");
+  }
+
+  const region = nonEmptyString(process.env.DASHSCOPE_REGION) || DEFAULT_REGION;
+  return `https://${workspaceId}.${region}.maas.aliyuncs.com/api/v1`;
+}
+
+function findImageUrl(payload) {
+  const content = payload?.output?.choices?.[0]?.message?.content;
+  if (Array.isArray(content)) {
+    const item = content.find((entry) => nonEmptyString(entry?.image));
+    if (item) return item.image;
+  }
+
+  const legacyUrl = payload?.output?.results?.[0]?.url || payload?.output?.url;
+  if (nonEmptyString(legacyUrl)) return legacyUrl;
+
+  return null;
+}
+
+async function readPrompt(args) {
+  const prompt = nonEmptyString(args.prompt);
+  if (prompt) return prompt;
+
+  const promptFile = nonEmptyString(args["prompt-file"]);
+  if (promptFile) {
+    return await import("node:fs/promises").then(({ readFile }) => readFile(resolve(promptFile), "utf8"));
+  }
+
+  throw new Error("A prompt is required. Pass --prompt or --prompt-file.");
+}
+
+async function downloadImage(imageUrl, outputPath) {
+  const response = await fetch(imageUrl);
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to download generated image: ${response.status} ${response.statusText}: ${text.slice(0, 500)}`);
+  }
+  const bytes = Buffer.from(await response.arrayBuffer());
+  await writeFile(outputPath, bytes);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || args.h) {
+    printUsage();
+    return;
+  }
+
+  const dashscopeConfig = await readDashscopeConfig();
+  const apiKey = nonEmptyString(process.env.DASHSCOPE_API_KEY) || nonEmptyString(dashscopeConfig.apiKey);
+  if (!apiKey) throw new Error("DASHSCOPE_API_KEY is required.");
+
+  const prompt = await readPrompt(args);
+  const model =
+    nonEmptyString(args.model) ||
+    nonEmptyString(process.env.COWART_DASHSCOPE_IMAGE_MODEL) ||
+    nonEmptyString(process.env.COWART_IMAGE_MODEL) ||
+    nonEmptyString(dashscopeConfig.model) ||
+    DEFAULT_MODEL;
+  const width = Number(args.width);
+  const height = Number(args.height);
+  const size =
+    nonEmptyString(args.size) ||
+    customSizeForDimensions(width, height, model === "wan2.7-image-pro" ? 4096 : 2048) ||
+    nonEmptyString(process.env.COWART_DASHSCOPE_IMAGE_SIZE) ||
+    DEFAULT_SIZE;
+
+  const outDir = resolve(nonEmptyString(args["out-dir"]) || nonEmptyString(process.env.COWART_GENERATED_IMAGE_DIR) || "generated-images");
+  await mkdir(outDir, { recursive: true });
+
+  const outputName = safeFileName(nonEmptyString(args.output) || `dashscope-${model}-${timestamp()}.png`);
+  const outputPath = resolve(outDir, outputName);
+  const endpoint = `${resolveBaseUrl(dashscopeConfig)}/services/aigc/multimodal-generation/generation`;
+
+  const body = {
+    model,
+    input: {
+      messages: [
+        {
+          role: "user",
+          content: [{ text: prompt }],
+        },
+      ],
+    },
+    parameters: {
+      size,
+      n: Number(args.n) || 1,
+      watermark: args.watermark === "true",
+    },
+  };
+
+  if (model === "wan2.7-image-pro" || model === "wan2.7-image") {
+    body.parameters.thinking_mode = args["thinking-mode"] === undefined ? true : args["thinking-mode"] !== "false";
+  }
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await response.text();
+  let payload;
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(`DashScope returned non-JSON response: ${text.slice(0, 500)}`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`DashScope request failed: ${response.status} ${response.statusText}: ${text.slice(0, 1000)}`);
+  }
+
+  const imageUrl = findImageUrl(payload);
+  if (!imageUrl) {
+    throw new Error(`DashScope response did not include an image URL: ${JSON.stringify(payload).slice(0, 1000)}`);
+  }
+
+  await downloadImage(imageUrl, outputPath);
+
+  const result = {
+    provider: "dashscope",
+    model,
+    size,
+    imageUrl,
+    outputPath,
+    responseId: payload?.request_id || payload?.requestId || null,
+  };
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/skills/cowart-image-gen/SKILL.md
+++ b/skills/cowart-image-gen/SKILL.md
@@ -77,7 +77,42 @@ meta flag. Support both shapes.
 
    Standalone workflow: when no AI holder is selected, generate the image anyway and insert it as a normal image shape on the current page. Prefer the current page from Cowart view state; if there is a selected non-holder shape and it is useful as context, place the image beside it, otherwise place it in a clear page area. If the user requested a size or aspect ratio, pass that size and ratio into generation and use it for display. Otherwise, use the generated bitmap's natural aspect ratio and a practical display width such as 512 canvas units.
 
-4. Generate the bitmap with the built-in `imagegen` skill unless the user explicitly requests another image path. If the requested asset needs visible copy, labels, poster text, ad text, UI text, or typography, include that text directly in the image generation prompt and let the image model produce the final bitmap. Do not default to generating a text-free background and then adding text locally unless the user explicitly asks for local typography, deterministic text overlay, SVG/vector output, or another non-imagegen layout step.
+4. Generate the bitmap with the configured provider. The default provider is OpenAI through the built-in `imagegen` skill; this must remain the fallback when no provider is configured. Before generation, read the Cowart model preference from `canvas/cowart-model-preferences.json` or the Cowart MCP `get_cowart_model_preferences` tool when available. Only use DashScope / Alibaba Qwen or Wan image generation when the user explicitly asks for it in the current request, when the Cowart UI preference has `imageProvider: "dashscope"`, or when `COWART_IMAGE_PROVIDER` is set to `dashscope`, `aliyun`, or `qwen`.
+
+   Provider selection:
+
+   - Default/OpenAI: use the built-in `imagegen` skill unless the user explicitly requests another image path or configured provider.
+   - DashScope/Alibaba: run `scripts/generate-dashscope-image.mjs` from the Cowart plugin directory to create a local bitmap file, then continue with the same Cowart insertion workflow. Use `preferences.imageModel` from `cowart-model-preferences.json` when it is present; otherwise use `COWART_DASHSCOPE_IMAGE_MODEL` or the script default.
+
+   For DashScope, required environment:
+
+   ```text
+   DASHSCOPE_API_KEY=<api-key>
+   DASHSCOPE_BASE_URL=https://<workspace-id>.cn-beijing.maas.aliyuncs.com/api/v1
+   ```
+
+   The user can also configure DashScope from the Cowart UI instead of environment variables: open the main menu, choose `模型选择` → `配置阿里千问`, then fill `DASHSCOPE_API_KEY`, `DASHSCOPE_BASE_URL`, and the model name. Cowart stores this machine-local config outside the project, under the user's Cowart config directory. The DashScope generation script reads that config automatically. Environment variables still override the UI config when both are present.
+
+   Optional environment:
+
+   ```text
+   COWART_IMAGE_PROVIDER=dashscope
+   COWART_DASHSCOPE_IMAGE_MODEL=wan2.7-image-pro
+   COWART_DASHSCOPE_IMAGE_SIZE=2K
+   ```
+
+   Example DashScope generation command:
+
+   ```bash
+   node scripts/generate-dashscope-image.mjs \
+     --prompt "Target canvas slot: 512 x 683 canvas units. Target aspect ratio: 3:4. Generate ..." \
+     --width 512 \
+     --height 683
+   ```
+
+   The script prints JSON containing `outputPath`. Use that exact local image path for insertion. Do not use DashScope if the script fails or the required environment variables are missing; tell the user what is missing instead of silently falling back to a different provider after they explicitly requested Alibaba/Qwen/Wan.
+
+   If the requested asset needs visible copy, labels, poster text, ad text, UI text, or typography, include that text directly in the image generation prompt and let the selected image model produce the final bitmap. Do not default to generating a text-free background and then adding text locally unless the user explicitly asks for local typography, deterministic text overlay, SVG/vector output, or another non-imagegen layout step.
 
    For the holder workflow, the image generation request must explicitly include the selected holder's target size and aspect ratio. Add this information to the model prompt, for example:
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,6 +45,7 @@ import {
 import { AllSelection } from '@tiptap/pm/state'
 import 'tldraw/tldraw.css'
 import { useCallback, useEffect, useState } from 'react'
+import { CowartMainMenu } from './CowartModelProviderMenu.jsx'
 import annotationToolIconRaw from './assets/tool-comment.svg?raw'
 import {
   describeSkippedRecord,
@@ -594,6 +595,7 @@ const cowartUiOverrides = {
 }
 
 const cowartComponents = {
+  MainMenu: CowartMainMenu,
   Toolbar: CowartToolbar,
   StylePanel: CowartStylePanel
 }
@@ -1082,10 +1084,7 @@ export default function App() {
     const selectionStateTimer = window.setInterval(syncSelectionState, 250)
 
     async function syncViewState() {
-      const viewStateSnapshot = {
-        ...getCowartViewState(editor),
-        updatedAt: new Date().toISOString()
-      }
+      const viewStateSnapshot = getCowartViewState(editor)
 
       const nextViewState = JSON.stringify(viewStateSnapshot)
       if (nextViewState === lastSyncedViewState) return
@@ -1101,7 +1100,10 @@ export default function App() {
         const response = await fetch(VIEW_STATE_ENDPOINT, {
           method: 'PUT',
           headers: { 'content-type': 'application/json' },
-          body: nextViewState
+          body: JSON.stringify({
+            ...viewStateSnapshot,
+            updatedAt: new Date().toISOString()
+          })
         })
         if (!response.ok) {
           throw new Error(`Failed to save view state: ${response.status}`)

--- a/src/CowartDashscopeConfigDialog.jsx
+++ b/src/CowartDashscopeConfigDialog.jsx
@@ -1,0 +1,200 @@
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+const DASHSCOPE_CONFIG_ENDPOINT = '/api/dashscope-config'
+const DEFAULT_DASHSCOPE_BASE_URL = 'https://<workspace-id>.cn-beijing.maas.aliyuncs.com/api/v1'
+const DEFAULT_DASHSCOPE_MODEL = 'wan2.7-image-pro'
+
+function emptyDashscopeConfig() {
+  return {
+    apiKey: '',
+    baseUrl: '',
+    model: DEFAULT_DASHSCOPE_MODEL,
+    configured: false,
+    apiKeyPreview: ''
+  }
+}
+
+function stopInputEvent(event) {
+  event.stopPropagation()
+}
+
+export function CowartDashscopeConfigDialog({ onClose }) {
+  const [config, setConfig] = useState(emptyDashscopeConfig)
+  const [apiKeyInput, setApiKeyInput] = useState('')
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSaving, setIsSaving] = useState(false)
+  const [message, setMessage] = useState('')
+  const [toast, setToast] = useState('')
+
+  useEffect(() => {
+    let isCancelled = false
+
+    async function loadConfig() {
+      try {
+        const response = await fetch(DASHSCOPE_CONFIG_ENDPOINT)
+        if (!response.ok) return
+        const payload = await response.json()
+        if (isCancelled) return
+        const nextConfig = {
+          ...emptyDashscopeConfig(),
+          ...payload.config
+        }
+        setConfig(nextConfig)
+      } catch {
+        if (!isCancelled) setMessage('读取配置失败')
+      } finally {
+        if (!isCancelled) setIsLoading(false)
+      }
+    }
+
+    loadConfig()
+
+    return () => {
+      isCancelled = true
+    }
+  }, [])
+
+  function updateConfig(field, value) {
+    setConfig((current) => ({ ...current, [field]: value }))
+  }
+
+  function stopDialogEvent(event) {
+    event.stopPropagation()
+  }
+
+  async function saveConfig(event) {
+    event.preventDefault()
+    setIsSaving(true)
+    setMessage('')
+
+    const apiKey = apiKeyInput.trim()
+    if (!apiKey && !config.configured) {
+      setMessage('请填写 DASHSCOPE_API_KEY')
+      setIsSaving(false)
+      return
+    }
+
+    if (!config.baseUrl.trim()) {
+      setMessage('请填写 DASHSCOPE_BASE_URL')
+      setIsSaving(false)
+      return
+    }
+
+    try {
+      const response = await fetch(DASHSCOPE_CONFIG_ENDPOINT, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          apiKey,
+          baseUrl: config.baseUrl,
+          model: config.model || DEFAULT_DASHSCOPE_MODEL
+        })
+      })
+      const payload = await response.json()
+      if (!response.ok) {
+        setMessage(payload?.error || '保存失败')
+        return
+      }
+      setConfig({ ...emptyDashscopeConfig(), ...payload.config })
+      setApiKeyInput('')
+      setToast('已保存')
+      window.setTimeout(onClose, 700)
+    } catch {
+      setMessage('保存失败')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const dialog = (
+    <div className="cowart-config-backdrop" role="presentation" onMouseDown={onClose}>
+      {toast && <div className="cowart-config-toast">{toast}</div>}
+      <form
+        aria-label="配置阿里千问"
+        className="cowart-config-dialog"
+        onClick={stopDialogEvent}
+        onKeyDown={stopDialogEvent}
+        onMouseDown={(event) => event.stopPropagation()}
+        onMouseDownCapture={stopDialogEvent}
+        onPointerDown={stopDialogEvent}
+        onPointerDownCapture={stopDialogEvent}
+        onPointerMove={stopDialogEvent}
+        onPointerMoveCapture={stopDialogEvent}
+        onPointerUp={stopDialogEvent}
+        onPointerUpCapture={stopDialogEvent}
+        onSubmit={saveConfig}
+        onWheel={stopDialogEvent}
+        onWheelCapture={stopDialogEvent}
+      >
+        <div className="cowart-config-dialog-header">
+          <h2>配置阿里千问</h2>
+          <button
+            aria-label="关闭"
+            onClick={(event) => {
+              event.stopPropagation()
+              onClose()
+            }}
+            onPointerDown={stopInputEvent}
+            type="button"
+          >
+            ×
+          </button>
+        </div>
+
+        <label className="cowart-config-field">
+          <span>DASHSCOPE_API_KEY</span>
+          <input
+            autoComplete="off"
+            disabled={isLoading || isSaving}
+            onChange={(event) => setApiKeyInput(event.target.value)}
+            onClick={stopInputEvent}
+            onKeyDown={stopInputEvent}
+            onPointerDown={stopInputEvent}
+            placeholder={config.configured ? config.apiKeyPreview : 'sk-...'}
+            type="password"
+            value={apiKeyInput}
+          />
+        </label>
+
+        <label className="cowart-config-field">
+          <span>DASHSCOPE_BASE_URL</span>
+          <input
+            disabled={isLoading || isSaving}
+            onChange={(event) => updateConfig('baseUrl', event.target.value)}
+            onClick={stopInputEvent}
+            onKeyDown={stopInputEvent}
+            onPointerDown={stopInputEvent}
+            placeholder={DEFAULT_DASHSCOPE_BASE_URL}
+            value={config.baseUrl}
+          />
+        </label>
+
+        <label className="cowart-config-field">
+          <span>模型</span>
+          <input
+            disabled={isLoading || isSaving}
+            onChange={(event) => updateConfig('model', event.target.value)}
+            onClick={stopInputEvent}
+            onKeyDown={stopInputEvent}
+            onPointerDown={stopInputEvent}
+            placeholder={DEFAULT_DASHSCOPE_MODEL}
+            value={config.model}
+          />
+        </label>
+
+        <div className="cowart-config-actions">
+          <span className="cowart-config-message">{message}</span>
+          <button className="cowart-config-cancel" onClick={onClose} type="button">
+            取消
+          </button>
+          <button disabled={isLoading || isSaving} type="submit">
+            保存
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+
+  return createPortal(dialog, document.body)
+}

--- a/src/CowartModelProviderMenu.jsx
+++ b/src/CowartModelProviderMenu.jsx
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  DefaultMainMenu,
+  DefaultMainMenuContent,
+  TldrawUiMenuCheckboxItem,
+  TldrawUiMenuGroup,
+  TldrawUiMenuSubmenu
+} from 'tldraw'
+import { CowartDashscopeConfigDialog } from './CowartDashscopeConfigDialog.jsx'
+
+const MODEL_PREFERENCES_ENDPOINT = '/api/model-preferences'
+
+const IMAGE_PROVIDER_OPTIONS = [
+  { id: 'openai', label: 'Codex 默认', model: 'openai' },
+  { id: 'dashscope', label: '阿里千问', model: 'wan2.7-image-pro' }
+]
+
+function useCowartImageProvider() {
+  const [provider, setProvider] = useState('openai')
+  const [isSaving, setIsSaving] = useState(false)
+
+  useEffect(() => {
+    let isCancelled = false
+
+    async function loadPreferences() {
+      try {
+        const response = await fetch(MODEL_PREFERENCES_ENDPOINT)
+        if (!response.ok) return
+        const payload = await response.json()
+        const nextProvider = payload?.preferences?.imageProvider
+        if (!isCancelled && IMAGE_PROVIDER_OPTIONS.some((option) => option.id === nextProvider)) {
+          setProvider(nextProvider)
+        }
+      } catch {
+        // Keep OpenAI as the UI default when preferences are not available.
+      }
+    }
+
+    loadPreferences()
+
+    return () => {
+      isCancelled = true
+    }
+  }, [])
+
+  const saveProvider = useCallback(async (nextProvider) => {
+    const option = IMAGE_PROVIDER_OPTIONS.find((item) => item.id === nextProvider) ?? IMAGE_PROVIDER_OPTIONS[0]
+    setProvider(option.id)
+    setIsSaving(true)
+
+    try {
+      await fetch(MODEL_PREFERENCES_ENDPOINT, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          version: 1,
+          imageProvider: option.id,
+          imageModel: option.model,
+          updatedAt: new Date().toISOString()
+        })
+      })
+    } catch {
+      setProvider('openai')
+    } finally {
+      setIsSaving(false)
+    }
+  }, [])
+
+  return { provider, isSaving, saveProvider }
+}
+
+export function CowartMainMenu(props) {
+  const [isDashscopeConfigOpen, setIsDashscopeConfigOpen] = useState(false)
+
+  return (
+    <>
+      <DefaultMainMenu {...props}>
+        <DefaultMainMenuContent />
+        <TldrawUiMenuGroup id="cowart-model-provider">
+          <CowartImageProviderMenu onConfigureDashscope={() => setIsDashscopeConfigOpen(true)} />
+        </TldrawUiMenuGroup>
+      </DefaultMainMenu>
+      {isDashscopeConfigOpen && (
+        <CowartDashscopeConfigDialog onClose={() => setIsDashscopeConfigOpen(false)} />
+      )}
+    </>
+  )
+}
+
+function CowartImageProviderMenu({ onConfigureDashscope }) {
+  const { provider, isSaving, saveProvider } = useCowartImageProvider()
+
+  return (
+    <TldrawUiMenuSubmenu id="cowart-model-provider" label="模型选择">
+      <TldrawUiMenuGroup id="cowart-model-provider-options">
+        <TldrawUiMenuCheckboxItem
+          checked={provider === 'openai'}
+          disabled={isSaving}
+          id="cowart-model-provider-openai"
+          label="Codex 默认"
+          onSelect={() => saveProvider('openai')}
+          readonlyOk
+        />
+        <button
+          className="tlui-button tlui-button__menu tlui-button__checkbox cowart-provider-menu-item"
+          disabled={isSaving}
+          onClick={() => saveProvider('dashscope')}
+          type="button"
+        >
+          <span className="cowart-provider-menu-check">{provider === 'dashscope' ? '✓' : ''}</span>
+          <span className="tlui-button__label cowart-provider-menu-label">阿里千问</span>
+          <span
+            className="cowart-provider-menu-config"
+            onClick={(event) => {
+              event.stopPropagation()
+              onConfigureDashscope()
+            }}
+            role="button"
+            tabIndex={0}
+          >
+            配置
+          </span>
+        </button>
+      </TldrawUiMenuGroup>
+    </TldrawUiMenuSubmenu>
+  )
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -103,6 +103,194 @@ body {
   border-radius: 1px;
 }
 
+.cowart-config-backdrop {
+  position: fixed;
+  z-index: 2147483000;
+  inset: 0;
+  display: grid;
+  padding: 24px;
+  place-items: center;
+  background: rgb(20 24 31 / 24%);
+}
+
+.cowart-config-dialog {
+  display: grid;
+  width: min(440px, calc(100vw - 32px));
+  padding: 16px;
+  gap: 14px;
+  color: var(--tl-color-text);
+  background: #fff;
+  border: 1px solid var(--tl-color-muted-1);
+  border-radius: 8px;
+  box-shadow: 0 18px 54px rgb(15 23 42 / 24%);
+}
+
+.cowart-config-toast {
+  position: fixed;
+  z-index: 2147483001;
+  top: 24px;
+  left: 50%;
+  padding: 8px 14px;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+  background: #1f2937;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgb(15 23 42 / 22%);
+  transform: translateX(-50%);
+}
+
+.cowart-config-dialog-header {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.cowart-config-dialog-header h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.cowart-config-dialog-header button {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  place-items: center;
+  color: var(--tl-color-text-2);
+  font: inherit;
+  font-size: 20px;
+  line-height: 1;
+  background: transparent;
+  border: 0;
+  border-radius: var(--tl-radius-2);
+  cursor: pointer;
+}
+
+.cowart-config-dialog-header button:hover {
+  background: var(--tl-color-muted-2);
+  color: var(--tl-color-text);
+}
+
+.cowart-config-field {
+  display: grid;
+  min-width: 0;
+  gap: 6px;
+}
+
+.cowart-config-field span {
+  color: var(--tl-color-text-2);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.cowart-config-field input {
+  width: 100%;
+  height: 36px;
+  min-width: 0;
+  padding: 0 10px;
+  color: var(--tl-color-text);
+  font: inherit;
+  font-size: 13px;
+  background: var(--tl-color-muted-2);
+  border: 1px solid #f0f0f0;
+  border-radius: var(--tl-radius-2);
+  outline: 0;
+}
+
+.cowart-config-field input:focus {
+  background: #fff;
+  border-color: #2f80ed;
+  box-shadow: 0 0 0 2px rgb(47 128 237 / 14%);
+}
+
+.cowart-config-actions {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.cowart-config-message {
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--tl-color-text-2);
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.cowart-config-actions button {
+  height: 34px;
+  padding: 0 14px;
+  color: #fff;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  background: #2f80ed;
+  border: 0;
+  border-radius: var(--tl-radius-2);
+  cursor: pointer;
+}
+
+.cowart-config-actions .cowart-config-cancel {
+  color: var(--tl-color-text);
+  background: #e5e7eb;
+}
+
+.cowart-config-actions .cowart-config-cancel:hover {
+  background: #d1d5db;
+}
+
+.cowart-config-actions button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.cowart-provider-menu-item {
+  display: flex;
+  width: 100%;
+  align-items: center;
+}
+
+.cowart-provider-menu-check {
+  display: inline-grid;
+  flex: 0 0 16px;
+  width: 16px;
+  place-items: center;
+  color: currentColor;
+  font-size: 13px;
+  line-height: 1;
+}
+
+.cowart-provider-menu-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  line-height: 1;
+  text-align: left;
+}
+
+.cowart-provider-menu-config {
+  flex: 0 0 auto;
+  margin-left: 12px;
+  color: #2f80ed;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.cowart-provider-menu-config:hover {
+  color: #1c5fb8;
+  text-decoration: underline;
+}
+
 .tlui-button__tool.cowart-annotation-toolbar-button {
   display: inline-flex;
   width: auto;

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 import { randomUUID } from 'node:crypto'
 import { createReadStream } from 'node:fs'
 import { copyFile, mkdir, readFile, readdir, rename, stat, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
 import { basename, dirname, extname, join, relative, resolve, sep } from 'node:path'
 
 const projectDir = resolve(process.env.COWART_PROJECT_DIR ?? process.cwd())
@@ -10,6 +11,12 @@ const canvasDir = resolve(process.env.COWART_CANVAS_DIR ?? join(projectDir, 'can
 const canvasFile = join(canvasDir, 'cowart-canvas.json')
 const selectionFile = join(canvasDir, 'cowart-selection.json')
 const viewStateFile = join(canvasDir, 'cowart-view-state.json')
+const modelPreferencesFile = join(canvasDir, 'cowart-model-preferences.json')
+const userConfigDir = resolve(
+  process.env.COWART_CONFIG_DIR ??
+    (process.env.APPDATA ? join(process.env.APPDATA, 'Cowart') : join(homedir(), '.cowart'))
+)
+const dashscopeConfigFile = join(userConfigDir, 'dashscope-config.json')
 const canvasPagesDir = join(canvasDir, 'pages')
 const canvasAssetsDir = join(canvasDir, 'assets')
 const pagesManifestFile = join(canvasPagesDir, 'manifest.json')
@@ -112,6 +119,46 @@ function isViewState(value) {
     isFiniteNumber(value.camera.y) &&
     isFiniteNumber(value.camera.z)
   )
+}
+
+function defaultModelPreferences() {
+  return {
+    version: 1,
+    imageProvider: 'openai',
+    imageModel: 'openai',
+    updatedAt: null
+  }
+}
+
+function isModelPreferences(value) {
+  return (
+    value &&
+    typeof value === 'object' &&
+    value.version === 1 &&
+    ['openai', 'dashscope'].includes(value.imageProvider) &&
+    (typeof value.imageModel === 'string' || value.imageModel === null)
+  )
+}
+
+function isDashscopeConfig(value) {
+  return (
+    value &&
+    typeof value === 'object' &&
+    typeof value.apiKey === 'string' &&
+    typeof value.baseUrl === 'string' &&
+    typeof value.model === 'string'
+  )
+}
+
+function publicDashscopeConfig(config) {
+  const apiKey = typeof config?.apiKey === 'string' ? config.apiKey : ''
+  return {
+    configured: apiKey.trim().length > 0,
+    baseUrl: typeof config?.baseUrl === 'string' ? config.baseUrl : '',
+    model: typeof config?.model === 'string' && config.model.trim() ? config.model : 'wan2.7-image-pro',
+    apiKeyPreview: apiKey ? `${apiKey.slice(0, 6)}...${apiKey.slice(-4)}` : '',
+    updatedAt: config?.updatedAt ?? null
+  }
 }
 
 function isSafeChildPath(parent, child) {
@@ -562,6 +609,116 @@ function canvasStoragePlugin() {
 
             await writeJsonAtomic(viewStateFile, viewState)
             sendJson(res, 200, { ok: true, path: viewStateFile })
+            return
+          }
+
+          res.statusCode = 405
+          res.setHeader('allow', 'GET, PUT')
+          res.end()
+        } catch (error) {
+          sendJson(res, 500, { error: error.message })
+        }
+      })
+
+      server.middlewares.use('/api/model-preferences', async (req, res) => {
+        try {
+          if (req.method === 'GET') {
+            try {
+              sendJson(res, 200, {
+                preferences: await readJsonFile(modelPreferencesFile),
+                path: modelPreferencesFile
+              })
+            } catch (error) {
+              if (error.code === 'ENOENT') {
+                sendJson(res, 200, {
+                  preferences: defaultModelPreferences(),
+                  path: modelPreferencesFile
+                })
+                return
+              }
+              throw error
+            }
+            return
+          }
+
+          if (req.method === 'PUT') {
+            const body = await readRequestBody(req)
+            const preferences = JSON.parse(body)
+            if (!isModelPreferences(preferences)) {
+              sendJson(res, 400, { error: 'Expected Cowart model preferences.' })
+              return
+            }
+
+            await writeJsonAtomic(modelPreferencesFile, {
+              ...preferences,
+              updatedAt: new Date().toISOString()
+            })
+            sendJson(res, 200, { ok: true, path: modelPreferencesFile })
+            return
+          }
+
+          res.statusCode = 405
+          res.setHeader('allow', 'GET, PUT')
+          res.end()
+        } catch (error) {
+          sendJson(res, 500, { error: error.message })
+        }
+      })
+
+      server.middlewares.use('/api/dashscope-config', async (req, res) => {
+        try {
+          if (req.method === 'GET') {
+            try {
+              sendJson(res, 200, {
+                config: publicDashscopeConfig(await readJsonFile(dashscopeConfigFile)),
+                path: dashscopeConfigFile
+              })
+            } catch (error) {
+              if (error.code === 'ENOENT') {
+                sendJson(res, 200, {
+                  config: publicDashscopeConfig({}),
+                  path: dashscopeConfigFile
+                })
+                return
+              }
+              throw error
+            }
+            return
+          }
+
+          if (req.method === 'PUT') {
+            const body = await readRequestBody(req)
+            const config = JSON.parse(body)
+            if (!isDashscopeConfig(config)) {
+              sendJson(res, 400, { error: 'Expected DashScope config.' })
+              return
+            }
+
+            let existingConfig = {}
+            try {
+              existingConfig = await readJsonFile(dashscopeConfigFile)
+            } catch (error) {
+              if (error.code !== 'ENOENT') throw error
+            }
+
+            const apiKey = config.apiKey.trim() || existingConfig.apiKey || ''
+            if (!apiKey) {
+              sendJson(res, 400, { error: 'DASHSCOPE_API_KEY is required.' })
+              return
+            }
+
+            const savedConfig = {
+              apiKey,
+              baseUrl: config.baseUrl.trim().replace(/\/+$/, ''),
+              model: config.model.trim() || 'wan2.7-image-pro',
+              updatedAt: new Date().toISOString()
+            }
+            await writeJsonAtomic(dashscopeConfigFile, savedConfig)
+            sendJson(res, 200, {
+              ok: true,
+              config: publicDashscopeConfig(savedConfig),
+              path: dashscopeConfigFile
+            })
             return
           }
 


### PR DESCRIPTION
## 概述

本 PR 为 Cowart 增加图片生成模型选择能力。

用户现在可以在左上角主菜单中通过「模型选择」在「Codex 默认」和「阿里千问」之间切换。选择阿里千问后，可以通过内置配置弹窗填写 `DASHSCOPE_API_KEY`、`DASHSCOPE_BASE_URL` 和模型名，默认模型为 `wan2.7-image-pro`。

默认行为保持不变：未选择阿里千问时，Cowart 仍然走 Codex 默认的图片生成流程。

## 主要改动

- 新增「模型选择」主菜单入口。
- 新增阿里千问配置弹窗。
- 将模型选择偏好保存到当前项目的 `canvas` 状态中。
- 将 DashScope 密钥保存到本机用户配置目录，避免写入项目目录。
- 新增 DashScope 图片生成脚本。
- 新增 MCP 模型偏好读取能力，供生成流程使用。
- 更新中英文 README 和 `cowart-image-gen` 技能说明。

## 验证

- 已运行 `node --check` 校验 MCP 和 DashScope 脚本。
- 已运行 `npm run build`。

## 功能截图
<img width="319" height="440" alt="image" src="https://github.com/user-attachments/assets/8398586b-d4f6-441d-a52f-be295187d2d8" />
<img width="441" height="322" alt="image" src="https://github.com/user-attachments/assets/4b7f4a39-1c1d-49dd-9e6d-0292a1cd4a3e" />
<img width="789" height="843" alt="image" src="https://github.com/user-attachments/assets/8f74ae2e-cf37-4990-af14-382e0dbec053" />

<img width="1610" height="892" alt="image" src="https://github.com/user-attachments/assets/7a26c13f-a968-4b2a-bfbd-cd99c3625d63" />
