### PR TITLE
[codex] fix Windows MCP probe path check

### DIFF
--- a/scripts/probe-mcp.mjs
+++ b/scripts/probe-mcp.mjs
@@ -64,7 +64,7 @@ try {
   if (stateResult.structuredContent?.storage !== "empty") {
     throw new Error("A fresh Cowart project should report empty storage.");
   }
-  if (!String(stateResult.structuredContent?.canvasDir || "").endsWith("/canvas")) {
+  if (path.basename(String(stateResult.structuredContent?.canvasDir || "")) !== "canvas") {
     throw new Error("Cowart canvas state did not report a project-local canvas directory.");
   }
 


### PR DESCRIPTION
## What changed

- Updated the MCP probe to validate the canvas directory by basename instead of checking for a POSIX-only `/canvas` suffix.

## Why

On Windows, `canvasDir` is reported with backslashes, so the existing probe failed even though the canvas directory was project-local.

## Validation

- `npm run quality`