### PR TITLE
fix(widget): keep openai:set_globals listener active until payload arrives

### DIFF
--- a/src/cowartClient.js
+++ b/src/cowartClient.js
@@ -80,7 +80,7 @@ async function waitForWidgetPayload(signal) {
       reject(abortError())
     }
 
-    window.addEventListener('openai:set_globals', handleGlobals, { once: true })
+    window.addEventListener('openai:set_globals', handleGlobals)
     signal?.addEventListener('abort', handleAbort, { once: true })
   })
 }


### PR DESCRIPTION
## 问题

在 MCP Apps host 里打开 Cowart 画布，widget 能加载出来，但立刻显示 **`Canvas file could not be loaded.`**

## 原因

`src/cowartClient.js` 的 `waitForWidgetPayload()` 用 `{ once: true }` 监听 `openai:set_globals`：

```js
window.addEventListener('openai:set_globals', handleGlobals, { once: true })
```

host 侧不保证「只 publish 一次 globals」，也不保证「第一次 publish 就带 `projectDir`」。标准 MCP Apps host 的顺序通常是：

1. `hostcontextchanged` → publish `hostContext` / `displayMode` / `widgetInstanceId`（**不含** `projectDir`/`canvasDir`）
2. `toolresult` → publish `toolOutput`（这一步才带 `projectDir`/`canvasDir`）

第 1 步就把 `once` 监听消耗掉了，而此时 `hasWidgetStorageTarget()` 仍是 `false`；第 2 步真正带 payload 到达时已经没有监听者。于是 5s 后 `waitForWidgetPayload` 以

```
Cowart widget storage target was not ready. Refusing to read or write without projectDir/canvasDir.
```

reject，`loadCowartCanvasState` 抛错，`App.jsx` 走 `loadError` 分支渲染上面那句提示。

## 修改

去掉 `{ once: true }`，让监听保持活跃直到 payload 真正到达。

同一个 Promise 里的 `cleanup()` 已经在 resolve / reject / abort 三条路径上都 `removeEventListener`，所以 `{ once: true }` 本来就是冗余的，没有泄漏风险。

## 验证

- 修改前：MCP Apps host 中打开画布 → 稳定复现 `Canvas file could not be loaded.`（server 侧正常：`render_cowart_canvas_widget` 返回的 `_meta.widgetData` 与 `structuredContent` 都带 `projectDir` / `canvasDir`，`get_cowart_canvas_state` 也能正确读到既有 snapshot）
- 修改后：画布正常打开并加载既有 canvas 数据。
- ChatGPT Apps / Codex 那条链路不受影响：如果 host 第一次 publish 就带 `projectDir`，`hasWidgetStorageTarget()` 在挂监听之前就已返回 `true`，直接走 early return。
