### PR TITLE
fix(widget): keep toolbar clear of Codex mini composer in fullscreen

### DIFF
--- a/mcp/lib/widget-resource.mjs
+++ b/mcp/lib/widget-resource.mjs
@@ -175,7 +175,12 @@ function mcpHostBridgeScript(appVersion) {
   let mcpApp = null;
 
   function publishHostGlobals(globals) {
-    window.openai = Object.assign(window.openai || {}, globals);
+    // Host context notifications are partial updates; never clobber a
+    // previously published value with undefined.
+    const definedGlobals = Object.fromEntries(
+      Object.entries(globals).filter(([, value]) => value !== undefined),
+    );
+    window.openai = Object.assign(window.openai || {}, definedGlobals);
     window.dispatchEvent(new CustomEvent("openai:set_globals", {
       detail: { globals: window.openai },
     }));
@@ -197,8 +202,17 @@ function mcpHostBridgeScript(appVersion) {
       // Host styling is a progressive enhancement.
     }
 
+    // Host context notifications are partial updates: merge over the
+    // previously published context so a notification that only carries a
+    // few fields does not drop the rest (e.g. safeAreaInsets).
+    const previousHostContext =
+      window.openai?.hostContext && typeof window.openai.hostContext === "object"
+        ? window.openai.hostContext
+        : null;
+    const mergedContext = { ...previousHostContext, ...context };
+
     publishHostGlobals({
-      hostContext: context,
+      hostContext: mergedContext,
       displayMode: context.displayMode,
       availableDisplayModes: context.availableDisplayModes,
       widgetInstanceId: context.widgetInstanceId || context.widgetId,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -123,6 +123,11 @@ const AI_IMAGE_GENERATION_PANEL_ESTIMATED_H = 226
 const AI_IMAGE_GENERATION_STATUS_RESET_MS = 2200
 const AI_IMAGE_REFERENCE_MAX_FILES = 10
 const SKIPPED_RECORDS_NOTICE_AUTO_HIDE_MS = 5000
+// Codex overlays its mini composer on top of the fullscreen widget panel,
+// which covers the tldraw main toolbar. Lift the bottom UI by a safe-area
+// inset while the widget is hosted in fullscreen display mode.
+const COWART_HOST_BOTTOM_INSET_FALLBACK_PX = 88
+const COWART_HOST_BOTTOM_INSET_MAX_PX = 240
 const COWART_HTML_DRAFT_URL_ORIGIN = 'http://cowart.local'
 const COWART_HTML_DRAFT_EMBED_TYPE = 'cowart_html_draft'
 const AI_IMAGE_ASPECT_PRESETS = [
@@ -5720,11 +5725,66 @@ function writeCowartSelectionState(selectionSnapshot) {
   })
 }
 
+// Host context notifications are partial updates: a safe-area-only change
+// arrives without displayMode, and a mode-only change arrives without
+// safeAreaInsets. Keep the last explicitly reported values so a fullscreen
+// session is not dropped back to inline styling mid-flight.
+let cowartLastReportedDisplayMode = null
+let cowartLastReportedSafeAreaInsets = null
+
+function readCowartHostContext() {
+  const openai = typeof window !== 'undefined' ? window.openai : null
+  const hostContext =
+    openai?.hostContext && typeof openai.hostContext === 'object' ? openai.hostContext : null
+  const reportedMode =
+    typeof openai?.displayMode === 'string' && openai.displayMode
+      ? openai.displayMode
+      : typeof hostContext?.displayMode === 'string' && hostContext.displayMode
+        ? hostContext.displayMode
+        : null
+  if (reportedMode) cowartLastReportedDisplayMode = reportedMode
+  const reportedInsets =
+    hostContext?.safeAreaInsets && typeof hostContext.safeAreaInsets === 'object'
+      ? hostContext.safeAreaInsets
+      : null
+  if (reportedInsets) cowartLastReportedSafeAreaInsets = reportedInsets
+  return {
+    displayMode: reportedMode ?? cowartLastReportedDisplayMode,
+    safeAreaInsets: reportedInsets ?? cowartLastReportedSafeAreaInsets
+  }
+}
+
+function useCowartHostContext() {
+  const [hostContext, setHostContext] = useState(readCowartHostContext)
+
+  useEffect(() => {
+    function handleHostGlobals() {
+      setHostContext(readCowartHostContext())
+    }
+    window.addEventListener('openai:set_globals', handleHostGlobals)
+    return () => window.removeEventListener('openai:set_globals', handleHostGlobals)
+  }, [])
+
+  return hostContext
+}
+
+function getCowartHostBottomInset(hostContext) {
+  if (hostContext.displayMode !== 'fullscreen') return 0
+  const safeBottom = Number(hostContext.safeAreaInsets?.bottom)
+  const inset =
+    Number.isFinite(safeBottom) && safeBottom > 0
+      ? Math.max(safeBottom, COWART_HOST_BOTTOM_INSET_FALLBACK_PX)
+      : COWART_HOST_BOTTOM_INSET_FALLBACK_PX
+  return Math.min(inset, COWART_HOST_BOTTOM_INSET_MAX_PX)
+}
+
 export default function App() {
   const [snapshot, setSnapshot] = useState()
   const [viewState, setViewState] = useState()
   const [loadError, setLoadError] = useState(null)
   const [skippedRecords, setSkippedRecords] = useState([])
+  const hostContext = useCowartHostContext()
+  const hostBottomInset = getCowartHostBottomInset(hostContext)
 
   useEffect(() => {
     const controller = new AbortController()
@@ -6094,7 +6154,14 @@ export default function App() {
   }
 
   return (
-    <main className="cowart-canvas" aria-label="Cowart infinite canvas">
+    <main
+      className="cowart-canvas"
+      aria-label="Cowart infinite canvas"
+      data-host-display-mode={hostContext.displayMode ?? undefined}
+      style={
+        hostBottomInset > 0 ? { '--cowart-host-bottom-inset': `${hostBottomInset}px` } : undefined
+      }
+    >
       <SkippedRecordsNotice records={skippedRecords} />
       <Tldraw
         snapshot={snapshot ?? undefined}

--- a/src/styles.css
+++ b/src/styles.css
@@ -26,6 +26,13 @@ body {
   min-height: 0;
 }
 
+/* Codex overlays its mini composer at the bottom of the fullscreen widget
+   panel and covers the tldraw main toolbar. Feed the host bottom inset into
+   tldraw's own safe-area variable so the bottom toolbar clears the composer. */
+.cowart-canvas[data-host-display-mode='fullscreen'] .tlui-layout {
+  --tl-sab: calc(env(safe-area-inset-bottom, 0px) + var(--cowart-host-bottom-inset, 88px));
+}
+
 .cowart-skipped-records {
   position: fixed;
   z-index: 1000;


### PR DESCRIPTION
## 问题

widget 在 Codex 里点击"展开面板"放大(fullscreen display mode)后,Codex 原生的迷你输入框会悬浮在面板底部中央,**完全遮挡 tldraw 的主工具栏**,导致无法切换工具。

## 修复

让 widget 感知宿主的 display mode 与安全区,在全屏时把底部 inset 注入 tldraw 自带的 `--tl-sab`(safe-area-bottom)变量,主工具栏随之抬升到迷你输入框上方;inline 模式行为不变。

具体改动(3 个文件):

- `mcp/lib/widget-resource.mjs`:桥接层 `publishHostGlobals` 跳过 `undefined` 值。宿主上下文通知是**部分更新**(例如只携带 safeAreaInsets 的更新),原实现会用 `undefined` 把之前发布的 `displayMode` 覆盖掉。
- `src/App.jsx`:新增 `useCowartHostContext`,通过 `openai:set_globals` 跟踪宿主 `displayMode`(对丢失的模式做粘性保持)和 `safeAreaInsets.bottom`;全屏时在根节点写入 `--cowart-host-bottom-inset`(优先用宿主上报值,兜底 88px,上限 240px)。
- `src/styles.css`:`[data-host-display-mode='fullscreen']` 下将 inset 以 `calc()` 叠加进 `.tlui-layout` 的 `--tl-sab`。

## 修复效果

![修复后:展开面板中主工具栏抬升到迷你输入框上方](https://raw.githubusercontent.com/gagagazan/Cowart/pr-assets/pr52-fullscreen-toolbar-fixed.png)

## 验证

- 实测环境:macOS,Codex 桌面版(宿主上报 `safeAreaInsets.bottom` 为 118–152px)。
- 展开面板后主工具栏完整可见、不再被迷你输入框遮挡;收起面板回到 inline 后工具栏位置恢复正常。
- `npm run quality`(插件校验、构建、三个 probe)全部通过,与 CI 一致。

## 备注

诊断过程中发现宿主部分上下文更新会丢 `displayMode` 的问题对任何消费该字段的 widget 都有影响,桥接层的 `undefined` 过滤对其他场景也有防御价值。另有无关本 PR 的宿主侧白屏问题,已单独提 issue #51。