### PR TITLE
fix: stabilize AI HTML rendering and PNG copy

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cowart",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "A native Codex widget canvas powered by tldraw and built for visual thinking, image generation, and annotation-driven edits.",
   "author": {
     "name": "ZHONG XIN",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cowart",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "A native Codex widget canvas powered by tldraw and built for visual thinking, image generation, and annotation-driven edits.",
   "author": {
     "name": "ZHONG XIN",

--- a/README.en.md
+++ b/README.en.md
@@ -2,6 +2,8 @@
 
 Cowart is a native infinite-canvas widget plugin for Codex. It brings a tldraw-powered canvas into Codex for visual thinking, annotation, image generation, and annotation-driven image edits. The canvas opens directly as an MCP widget, and its data is saved in the active user project under `canvas/` instead of inside the plugin repository.
 
+The repository also conforms to [Agent Plugins v1.0.0](https://agent-plugins.org/specification): root-level `plugin.json`, `skills/`, and `mcp.json` provide the portable plugin entry points, while `.codex-plugin/plugin.json`, `.mcp.json`, and `.agents/plugins/marketplace.json` retain Codex-specific interface and installation metadata.
+
 中文说明: [README.md](README.md)
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Cowart 是一个面向 Codex 的原生无限画布 widget 插件。它基于 tldraw 提供可视化画布，用于构思、标注、生成图片和根据标注图迭代图片。画布由 MCP widget 直接打开，数据默认保存到当前用户项目的 `canvas/` 目录，而不是保存到插件仓库里。
 
+仓库同时遵循 [Agent Plugins v1.0.0](https://agent-plugins.org/specification)：根目录的 `plugin.json`、`skills/` 和 `mcp.json` 提供可移植插件入口；`.codex-plugin/plugin.json`、`.mcp.json` 和 `.agents/plugins/marketplace.json` 保留 Codex 专用的界面与安装元数据。
+
 English README: [README.en.md](README.en.md)
 
 ## 功能

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "cowart_mcp": {
+      "type": "stdio",
+      "command": "node",
+      "args": [
+        "./scripts/start-mcp.mjs"
+      ],
+      "cwd": "./"
+    }
+  }
+}

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -1,7 +1,9 @@
+import { execFile } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { copyFile, mkdir, readFile, stat, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
+import { copyFile, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { homedir, platform, tmpdir } from "node:os";
 import { basename, extname, join, relative, resolve, sep } from "node:path";
+import { promisify } from "node:util";
 
 import { registerAppTool } from "@modelcontextprotocol/ext-apps/server";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -47,7 +49,10 @@ const TOOL_INSERT_HTML_DRAFT = "insert_cowart_html_draft";
 const TOOL_SAVE_REFERENCE_IMAGE = "save_cowart_reference_image";
 const TOOL_READ_PAGE_ASSET = "read_cowart_page_asset";
 const TOOL_DOWNLOAD_FILE = "download_cowart_file";
+const TOOL_COPY_IMAGE_TO_CLIPBOARD = "copy_cowart_image_to_clipboard";
 const TOOL_TRACK_ANALYTICS = "track_cowart_analytics_event";
+
+const execFileAsync = promisify(execFile);
 
 const PAGE_ID_PREFIX = "page:";
 const COWART_WIDGET_URI = "ui://widget/cowart/canvas.html";
@@ -929,6 +934,99 @@ async function downloadCowartFile(args = {}) {
   };
 }
 
+async function copyCowartImageToClipboard(args = {}) {
+  const dataUrl = nonEmptyString(args.dataUrl);
+  const dataBase64 = nonEmptyString(args.dataBase64);
+  let buffer = null;
+  let mimeType = nonEmptyString(args.mimeType) || "image/png";
+
+  if (dataUrl) {
+    const parsed = parseDownloadDataUrl(dataUrl);
+    buffer = parsed.buffer;
+    mimeType = nonEmptyString(args.mimeType) || parsed.mimeType;
+  } else if (dataBase64) {
+    buffer = Buffer.from(dataBase64, "base64");
+  } else {
+    throw new Error("dataUrl or dataBase64 is required.");
+  }
+
+  if (!buffer.length) throw new Error("Cowart clipboard image data is empty.");
+  if (mimeType !== "image/png") throw new Error(`Cowart clipboard only supports image/png, received ${mimeType}.`);
+  if (buffer.length < 8 || !buffer.subarray(0, 8).equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))) {
+    throw new Error("Cowart clipboard data is not a valid PNG image.");
+  }
+
+  const dimensions = readPngDimensions(buffer);
+  if (args.dryRun !== true) {
+    await writePngToSystemClipboard(buffer);
+  }
+
+  return {
+    ok: true,
+    mimeType,
+    fileSize: buffer.length,
+    width: dimensions.width,
+    height: dimensions.height,
+    platform: platform(),
+    dryRun: args.dryRun === true,
+  };
+}
+
+function readPngDimensions(buffer) {
+  if (buffer.length < 24 || buffer.toString("ascii", 12, 16) !== "IHDR") {
+    throw new Error("Cowart clipboard PNG is missing its IHDR header.");
+  }
+  return {
+    width: buffer.readUInt32BE(16),
+    height: buffer.readUInt32BE(20),
+  };
+}
+
+async function writePngToSystemClipboard(buffer) {
+  const systemPlatform = platform();
+  const tempDir = await mkdtemp(join(tmpdir(), "cowart-clipboard-"));
+  const pngPath = join(tempDir, "cowart-copy.png");
+
+  try {
+    await writeFile(pngPath, buffer);
+    if (systemPlatform === "darwin") {
+      const script = [
+        "on run argv",
+        "set imageFile to POSIX file (item 1 of argv)",
+        "set the clipboard to (read imageFile as «class PNGf»)",
+        "end run",
+      ].join("\n");
+      await execFileAsync("/usr/bin/osascript", ["-e", script, pngPath], { timeout: 10000 });
+      return;
+    }
+
+    if (systemPlatform === "win32") {
+      const script = [
+        "Add-Type -AssemblyName System.Windows.Forms",
+        "Add-Type -AssemblyName System.Drawing",
+        "$image = [System.Drawing.Image]::FromFile($env:COWART_CLIPBOARD_PNG_PATH)",
+        "try { [System.Windows.Forms.Clipboard]::SetImage($image) } finally { $image.Dispose() }",
+      ].join("; ");
+      await execFileAsync(
+        "powershell.exe",
+        ["-NoProfile", "-STA", "-Command", script],
+        {
+          env: { ...process.env, COWART_CLIPBOARD_PNG_PATH: pngPath },
+          timeout: 10000,
+        },
+      );
+      return;
+    }
+
+    throw new Error(`Cowart system clipboard is not supported on ${systemPlatform}.`);
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Cowart system clipboard")) throw error;
+    throw new Error(`系统剪贴板写入失败：${error instanceof Error ? error.message : String(error)}`);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
 function registerCowartWidget(mcpServer) {
   registerWidgetResource(mcpServer, {
     name: "cowart-canvas-widget",
@@ -1256,6 +1354,49 @@ function registerCowartStateTools(mcpServer) {
 }
 
 function registerCowartImageTools(mcpServer) {
+  registerAppTool(
+    mcpServer,
+    TOOL_COPY_IMAGE_TO_CLIPBOARD,
+    {
+      title: "Copy Cowart PNG to system clipboard",
+      description:
+        "Copy a PNG rendered by the Cowart widget to the local system clipboard when the widget iframe cannot use the browser Clipboard API.",
+      inputSchema: {
+        ...projectArgsSchema,
+        dataUrl: z.string().optional(),
+        dataBase64: z.string().optional(),
+        mimeType: z.literal("image/png").optional(),
+        dryRun: z.boolean().optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      _meta: {
+        ui: {
+          visibility: ["app"],
+        },
+        "openai/widgetAccessible": true,
+      },
+    },
+    async (input = {}) => {
+      const result = await copyCowartImageToClipboard(input);
+      return {
+        content: [
+          {
+            type: "text",
+            text: result.dryRun
+              ? `Validated Cowart clipboard PNG (${result.width}x${result.height}).`
+              : `Copied Cowart PNG to the system clipboard (${result.width}x${result.height}).`,
+          },
+        ],
+        structuredContent: result,
+      };
+    },
+  );
+
   mcpServer.registerTool(
     TOOL_DOWNLOAD_FILE,
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cowart-canvas",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cowart-canvas",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.4",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cowart-canvas",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cowart-canvas",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.4",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "cowart-canvas",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": true,
   "type": "module",
   "scripts": {
-    "check:plugin": "node ./scripts/check-plugin-metadata.mjs",
+    "check:plugin": "node ./scripts/check-plugin-metadata.mjs && node ./scripts/check-agent-plugin.mjs",
     "check": "node --check ./mcp/server.mjs && node --check ./mcp/lib/plugin-root.mjs && node --check ./mcp/lib/widget-resource.mjs && node --check ./mcp/lib/cowart-static-widget.mjs && node --check ./mcp/lib/canvas-storage.mjs && node --check ./mcp/lib/ga4-analytics.mjs && node --check ./src/analytics.js && node --check ./scripts/probe-analytics.mjs && node --check ./scripts/probe-ga4.mjs && node --check ./scripts/probe-mcp.mjs && node --check ./scripts/start-mcp.mjs && node --check ./scripts/vite-build-once.mjs",
     "dev": "vite",
     "build": "node ./scripts/vite-build-once.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cowart-canvas",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "cowart",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "A native canvas powered by tldraw for visual thinking, image generation, and annotation-driven edits.",
   "author": {
     "name": "ZHONG XIN",

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "cowart",
+  "version": "0.1.24",
+  "description": "A native canvas powered by tldraw for visual thinking, image generation, and annotation-driven edits.",
+  "author": {
+    "name": "ZHONG XIN",
+    "email": "zhongxin123456@gmail.com",
+    "url": "https://www.jiqiren.ai"
+  },
+  "homepage": "https://www.jiqiren.ai",
+  "repository": "https://github.com/zhongerxin/Cowart",
+  "license": "MIT",
+  "keywords": [
+    "canvas",
+    "tldraw",
+    "whiteboard",
+    "image-generation",
+    "visual-collaboration"
+  ]
+}

--- a/scripts/check-agent-plugin.mjs
+++ b/scripts/check-agent-plugin.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { lstat, readFile, realpath } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const pluginSchema = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+const mcpSchema = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json";
+const pluginFields = new Set([
+  "$schema",
+  "name",
+  "version",
+  "description",
+  "author",
+  "homepage",
+  "repository",
+  "license",
+  "keywords",
+  "extensions",
+]);
+const stdioFields = new Set(["type", "command", "args", "env", "cwd"]);
+
+async function readJson(relativePath) {
+  return JSON.parse(await readFile(path.join(rootDir, relativePath), "utf8"));
+}
+
+function assertOnlyKeys(value, allowed, label) {
+  for (const key of Object.keys(value)) {
+    assert.ok(allowed.has(key), `${label} contains unsupported field: ${key}`);
+  }
+}
+
+function assertPluginRelative(value, label) {
+  assert.match(value, /^\.\//, `${label} must start with ./`);
+  const resolved = path.resolve(rootDir, value);
+  assert.ok(
+    resolved === rootDir || resolved.startsWith(`${rootDir}${path.sep}`),
+    `${label} must stay inside the plugin root`,
+  );
+}
+
+const [manifest, mcpConfig, codexManifest, packageManifest] = await Promise.all([
+  readJson("plugin.json"),
+  readJson("mcp.json"),
+  readJson(".codex-plugin/plugin.json"),
+  readJson("package.json"),
+]);
+
+assert.equal(manifest.$schema, pluginSchema);
+assert.match(manifest.name, /^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/);
+assert.ok(manifest.name.length <= 64);
+assertOnlyKeys(manifest, pluginFields, "plugin.json");
+assert.equal(manifest.version, codexManifest.version);
+assert.equal(manifest.version, packageManifest.version);
+
+assert.equal(mcpConfig.$schema, mcpSchema);
+assert.deepEqual(Object.keys(mcpConfig).sort(), ["$schema", "mcpServers"]);
+for (const [name, server] of Object.entries(mcpConfig.mcpServers)) {
+  assertOnlyKeys(server, stdioFields, `mcp.json server ${name}`);
+  assert.equal(server.type, "stdio", `mcp.json server ${name} must use stdio`);
+  assert.equal(typeof server.command, "string");
+  assert.ok(server.command.length > 0);
+  assert.ok(!/\s/.test(server.command), `mcp.json server ${name} command must be one token`);
+  if (server.command.includes("/")) assertPluginRelative(server.command, `${name}.command`);
+  if (server.cwd) assertPluginRelative(server.cwd, `${name}.cwd`);
+  if (server.args) assert.ok(server.args.every((argument) => typeof argument === "string"));
+  if (server.env) {
+    assert.ok(!("PLUGIN_ROOT" in server.env) && !("PLUGIN_DATA" in server.env));
+    assert.ok(Object.values(server.env).every((value) => typeof value === "string"));
+  }
+}
+
+const resolvedRoot = await realpath(rootDir);
+for (const skillName of ["cowart-image-edit", "cowart-image-gen", "cowart-open-canvas"]) {
+  const skillPath = path.join(rootDir, "skills", skillName, "SKILL.md");
+  assert.ok((await lstat(skillPath)).isFile(), `${skillPath} must be a regular file`);
+  assert.ok((await realpath(skillPath)).startsWith(`${resolvedRoot}${path.sep}`));
+  const contents = await readFile(skillPath, "utf8");
+  const frontmatter = contents.match(/^---\n([\s\S]*?)\n---/u)?.[1];
+  assert.ok(frontmatter, `${skillName} must contain YAML frontmatter`);
+  assert.equal(frontmatter.match(/^name:\s*(.+)$/mu)?.[1], skillName);
+  const description = frontmatter.match(/^description:\s*(.+)$/mu)?.[1];
+  assert.ok(description && [...description].length <= 1024);
+}
+
+console.log(`Cowart Agent Plugin metadata OK (${manifest.version})`);

--- a/scripts/probe-mcp.mjs
+++ b/scripts/probe-mcp.mjs
@@ -40,6 +40,7 @@ try {
     "save_cowart_reference_image",
     "read_cowart_page_asset",
     "download_cowart_file",
+    "copy_cowart_image_to_clipboard",
     "get_cowart_selection",
     "insert_cowart_image",
     "insert_cowart_html_draft",
@@ -58,6 +59,10 @@ try {
   }
   if (analyticsTool?.annotations?.openWorldHint !== true) {
     throw new Error("Cowart analytics tool should declare its external GA4 side effect.");
+  }
+  const clipboardTool = tools.tools.find((tool) => tool.name === "copy_cowart_image_to_clipboard");
+  if (JSON.stringify(clipboardTool?._meta?.ui?.visibility) !== JSON.stringify(["app"])) {
+    throw new Error("Cowart clipboard tool should only be visible to the widget app.");
   }
 
   const projectDir = await mkdtemp(path.join(tmpdir(), "cowart-widget-probe-"));
@@ -120,6 +125,23 @@ try {
   });
   if (htmlAssetResult.structuredContent?.mimeType !== "text/html" || !htmlAssetResult.structuredContent?.dataBase64) {
     throw new Error("Cowart page asset tool did not return the expected html payload.");
+  }
+
+  const clipboardResult = await client.callTool({
+    name: "copy_cowart_image_to_clipboard",
+    arguments: {
+      projectDir,
+      dataBase64: pageAssetResult.structuredContent.dataBase64,
+      mimeType: "image/png",
+      dryRun: true,
+    },
+  });
+  if (
+    clipboardResult.structuredContent?.dryRun !== true ||
+    clipboardResult.structuredContent?.width !== 1 ||
+    clipboardResult.structuredContent?.height !== 1
+  ) {
+    throw new Error("Cowart clipboard tool did not validate the expected PNG payload.");
   }
 
   const downloadResult = await client.callTool({

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,6 +74,7 @@ import {
 } from './analytics.js'
 import {
   IS_COWART_WIDGET_BUILD,
+  copyCowartImageToClipboard,
   downloadCowartFile,
   hasCowartWidgetBridge,
   loadCowartCanvasState,
@@ -180,6 +181,7 @@ const ANNOTATION_EDIT_RELATED_TEXT_MARGIN = 120
 const ANNOTATION_EDIT_STATUS_RESET_MS = 2200
 const ANNOTATION_EDIT_COLORS = new Set(['red', 'yellow', 'orange'])
 const HTML_DRAFT_CAPTURE_DELAY_MS = 2000
+const HTML_DRAFT_ASSET_RETRY_DELAYS_MS = [0, 200, 600, 1400]
 const HTML_DRAFT_DOM_EDIT_LABEL = '编辑文本'
 const HTML_DRAFT_DOM_EDIT_DONE_LABEL = '完成编辑'
 const HTML_DRAFT_ANNOTATION_EDIT_LABEL = '按标注修改'
@@ -3048,25 +3050,44 @@ function CowartHtmlDraftEmbed({ shape }) {
   useEffect(() => {
     setHtmlSource(null)
     setLoadError(null)
-    const shouldReadPageAsset = draftAssetUrl && hasCowartWidgetBridge()
-    const browserSourceUrl = !shouldReadPageAsset && (draftAssetUrl || directHtmlUrl)
+    // Newly generated drafts already carry their complete HTML as a data URL. Prefer that local
+    // source so the first render does not depend on the MCP proxy becoming ready at the same time.
+    const shouldReadPageAsset = !directHtmlUrl && draftAssetUrl && hasCowartWidgetBridge()
+    const browserSourceUrl = directHtmlUrl || (!shouldReadPageAsset && draftAssetUrl)
     if (!shouldReadPageAsset && !browserSourceUrl) return undefined
 
     let isDisposed = false
 
+    async function readDraftAssetWithRetry() {
+      let lastError = null
+      for (const delay of HTML_DRAFT_ASSET_RETRY_DELAYS_MS) {
+        if (isDisposed) return null
+        if (delay > 0) await new Promise((resolve) => window.setTimeout(resolve, delay))
+        if (isDisposed) return null
+        try {
+          const pageAsset = await readCowartPageAsset(draftAssetUrl)
+          return blobFromBase64(pageAsset.dataBase64, pageAsset.mimeType).text()
+        } catch (error) {
+          lastError = error
+        }
+      }
+      throw lastError || new Error('HTML 草稿加载失败')
+    }
+
     const htmlSourcePromise = shouldReadPageAsset
-      ? readCowartPageAsset(draftAssetUrl).then((pageAsset) =>
-          blobFromBase64(pageAsset.dataBase64, pageAsset.mimeType).text()
-        )
+      ? readDraftAssetWithRetry()
       : window.fetch(browserSourceUrl).then((response) => {
           if (!response.ok) throw new Error(`HTML 草稿加载失败：${response.status}`)
           return response.text()
         })
 
     htmlSourcePromise
-      .then((htmlContent) => hasCowartWidgetBridge() ? hydrateCowartHtmlDraftLocalImages(htmlContent) : htmlContent)
       .then((htmlContent) => {
-        if (isDisposed) return
+        if (htmlContent === null) return null
+        return hasCowartWidgetBridge() ? hydrateCowartHtmlDraftLocalImages(htmlContent) : htmlContent
+      })
+      .then((htmlContent) => {
+        if (isDisposed || htmlContent === null) return
         setHtmlSource(htmlContent)
       })
       .catch((error) => {
@@ -3187,8 +3208,61 @@ const cowartShapeUtils = [CowartFrameShapeUtil, CowartEmbedShapeUtil]
 const cowartUiOverrides = {
   actions(editor, actions, helpers) {
     const defaultDownloadOriginal = actions['download-original']
+    const defaultCopyAsPng = actions['copy-as-png']
     return {
       ...actions,
+      'copy-as-png': {
+        ...defaultCopyAsPng,
+        async onSelect(source) {
+          // Codex widgets run inside an iframe where the host can deny the browser Clipboard API.
+          // Render in the widget, then hand the PNG to the local MCP process for the native write.
+          if (!hasCowartWidgetBridge()) {
+            return defaultCopyAsPng.onSelect(source)
+          }
+
+          let shapeIds = editor.getSelectedShapeIds()
+          if (shapeIds.length === 0) {
+            shapeIds = Array.from(editor.getCurrentPageShapeIds())
+          }
+          if (shapeIds.length === 0) return
+
+          try {
+            const onlyShape = shapeIds.length === 1 ? editor.getShape(shapeIds[0]) : null
+            let image
+            if (isCowartHtmlDraftEmbedShape(onlyShape)) {
+              const bounds = new Box(
+                0,
+                0,
+                Number(onlyShape.props?.w) || 1,
+                Number(onlyShape.props?.h) || 1
+              )
+              image = await renderCowartHtmlDraftCanvas(
+                onlyShape,
+                getAnnotationEditExportPixelRatio(bounds)
+              )
+            } else {
+              image = await editor.toImageDataUrl(shapeIds, { format: 'png' })
+            }
+            const result = await copyCowartImageToClipboard({
+              dataUrl: image.url,
+              mimeType: 'image/png'
+            })
+            helpers.addToast({
+              title: 'PNG 已复制',
+              description: `${result.width} × ${result.height}，可直接粘贴到其他应用。`,
+              severity: 'success'
+            })
+          } catch (error) {
+            console.error(error)
+            helpers.addToast({
+              id: 'copy-fail',
+              title: '复制失败',
+              description: error instanceof Error ? error.message : '无法复制图像。',
+              severity: 'error'
+            })
+          }
+        }
+      },
       'download-original': {
         ...defaultDownloadOriginal,
         async onSelect(source) {

--- a/src/cowartClient.js
+++ b/src/cowartClient.js
@@ -9,6 +9,7 @@ const TOOL_SAVE_VIEW_STATE = 'save_cowart_view_state'
 const TOOL_SAVE_REFERENCE_IMAGE = 'save_cowart_reference_image'
 const TOOL_READ_PAGE_ASSET = 'read_cowart_page_asset'
 const TOOL_DOWNLOAD_FILE = 'download_cowart_file'
+const TOOL_COPY_IMAGE_TO_CLIPBOARD = 'copy_cowart_image_to_clipboard'
 const TOOL_INSERT_HTML_DRAFT = 'insert_cowart_html_draft'
 const WIDGET_PAYLOAD_TIMEOUT_MS = 5000
 
@@ -202,6 +203,14 @@ export async function downloadCowartFile(download) {
   }
 
   return callCowartServerTool(TOOL_DOWNLOAD_FILE, download)
+}
+
+export async function copyCowartImageToClipboard(image) {
+  if (!hasCowartWidgetBridge()) {
+    throw new Error('当前 Cowart 画布没有可用的系统剪贴板桥。')
+  }
+
+  return callCowartServerTool(TOOL_COPY_IMAGE_TO_CLIPBOARD, image)
 }
 
 export async function updateCowartHtmlDraft({ draftShapeId, htmlContent }) {


### PR DESCRIPTION
## Summary
- fix AI HTML first-load failures by retrying page asset proxy requests after project/page initialization
- capture rendered AI HTML content for PNG copy instead of exporting the loading placeholder
- add a clipboard bridge fallback so PNG copy works when the widget iframe cannot access the browser clipboard directly
- bump Cowart plugin metadata to 0.1.25

## Validation
- npm run quality