### PR TITLE
Add Codex restart reminder

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -18,6 +18,9 @@ The repository also conforms to [Agent Plugins v1.0.0](https://agent-plugins.org
 
 ## Installation
 
+> [!IMPORTANT]
+> After installation, completely quit and restart Codex once before using Cowart. Restarting ensures that Cowart's new skills and MCP tools are fully loaded.
+
 ### Ask Codex To Install It
 
 Send the following message to Codex:
@@ -26,8 +29,8 @@ Send the following message to Codex:
 Please install the Cowart Codex plugin through the Git marketplace bundled with its repository.
 First run codex plugin marketplace add zhongerxin/Cowart --ref main,
 then run codex plugin add cowart@cowart-github and use codex plugin list to confirm it is enabled.
-Do not clone the repository into the personal marketplace. When installation finishes, tell me to
-start a new task so Codex loads Cowart's new skills and MCP tools.
+Do not clone the repository into the personal marketplace. When installation finishes, clearly remind me
+to completely quit and restart Codex once before using Cowart.
 ```
 
 ### Manual Install
@@ -45,7 +48,7 @@ codex plugin add cowart@cowart-github
 codex plugin list
 ```
 
-If `cowart-github` is already registered, skip the first `marketplace add` command. After installing, start a new Codex task so the new skills and MCP tools are loaded cleanly.
+If `cowart-github` is already registered, skip the first `marketplace add` command. After installing, completely quit and restart Codex once so the new skills and MCP tools are fully loaded.
 
 Codex automatically checks this Git marketplace when its plugin system starts and refreshes the installed Cowart plugin when the remote `main` branch changes. To check for an update immediately, run:
 
@@ -53,7 +56,7 @@ Codex automatically checks this Git marketplace when its plugin system starts an
 codex plugin marketplace upgrade cowart-github
 ```
 
-Start a new task after the update as well.
+Restart Codex after the update as well.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ English README: [README.en.md](README.en.md)
 
 ## 安装
 
+> [!IMPORTANT]
+> 安装完成后，请务必完全退出并重新启动一次 Codex，再开始使用 Cowart。重启后，Cowart 的新技能和 MCP 工具才能完整加载。
+
 ### 让 Codex 自动安装
 
 把下面这段发给 Codex：
@@ -26,8 +29,8 @@ English README: [README.en.md](README.en.md)
 请通过 Cowart 仓库自带的 Git marketplace 安装 Cowart Codex 插件。
 先运行 codex plugin marketplace add zhongerxin/Cowart --ref main，
 再运行 codex plugin add cowart@cowart-github，并用 codex plugin list 确认插件已启用。
-不要把仓库 clone 到 personal marketplace。安装完成后请告诉我开启一个新任务，
-以便加载 Cowart 的新技能和 MCP 工具。
+不要把仓库 clone 到 personal marketplace。安装完成后请明确提醒我：
+必须完全退出并重新启动一次 Codex，再开始使用 Cowart。
 ```
 
 ### 手动安装
@@ -45,7 +48,7 @@ codex plugin add cowart@cowart-github
 codex plugin list
 ```
 
-如果 `cowart-github` 已经注册，可以跳过第一条 `marketplace add` 命令。安装后请开启一个新的 Codex 任务，让新的 skill 和 MCP 工具完整加载。
+如果 `cowart-github` 已经注册，可以跳过第一条 `marketplace add` 命令。安装后请完全退出并重新启动一次 Codex，让新的 skill 和 MCP 工具完整加载。
 
 Codex 会在启动插件系统时自动检查这个 Git marketplace，并在远程 `main` 分支发生变化后刷新已安装的 Cowart。需要立即检查更新时，可以手动运行：
 
@@ -53,7 +56,7 @@ Codex 会在启动插件系统时自动检查这个 Git marketplace，并在远�
 codex plugin marketplace upgrade cowart-github
 ```
 
-更新完成后同样建议开启一个新任务。
+更新完成后同样建议重新启动 Codex。
 
 ## 使用
 


### PR DESCRIPTION
## What changed

- Added a prominent installation reminder in the Chinese and English READMEs.
- Updated automatic and manual installation instructions to require fully quitting and restarting Codex.
- Updated the post-upgrade guidance for consistency.

## Why

Cowart skills and MCP tools need Codex to restart before they are fully loaded. The previous guidance only asked users to start a new task, which was insufficient.

## Validation

- `git diff --check`
